### PR TITLE
feat: manage campaign members

### DIFF
--- a/RpgRooms.Core/Application/Interfaces/ICampaignService.cs
+++ b/RpgRooms.Core/Application/Interfaces/ICampaignService.cs
@@ -12,6 +12,9 @@ public interface ICampaignService
     Task ApproveJoinRequestAsync(Guid campaignId, Guid requestId, string gmUserId);
     Task RejectJoinRequestAsync(Guid campaignId, Guid requestId, string gmUserId);
 
+    Task<IReadOnlyList<JoinRequest>> ListJoinRequestsAsync(Guid campaignId, string gmUserId);
+    Task<IReadOnlyList<CampaignMember>> ListMembersAsync(Guid campaignId, string gmUserId);
+
     Task RemoveMemberAsync(Guid campaignId, string targetUserId, string gmUserId, string? reason = null);
 
     Task<IReadOnlyList<Campaign>> ListCampaignsAsync(string? search, bool recruitingOnly, string? ownerUserId, string? status);

--- a/RpgRooms.Core/Application/Services/CampaignService.cs
+++ b/RpgRooms.Core/Application/Services/CampaignService.cs
@@ -121,6 +121,26 @@ public class CampaignService : ICampaignService
         await Audit("RejectJoin", gmUserId, campaignId, new { req.UserId });
     }
 
+    public async Task<IReadOnlyList<JoinRequest>> ListJoinRequestsAsync(Guid campaignId, string gmUserId)
+    {
+        var c = await _db.Campaigns.FindAsync(campaignId) ?? throw new InvalidOperationException("Campanha não encontrada");
+        if (c.OwnerUserId != gmUserId) throw new UnauthorizedAccessException("Apenas o GM pode ver solicitações.");
+        return await _db.JoinRequests
+            .Where(r => r.CampaignId == campaignId && r.Status == JoinRequestStatus.Pending)
+            .OrderBy(r => r.CreatedAt)
+            .ToListAsync();
+    }
+
+    public async Task<IReadOnlyList<CampaignMember>> ListMembersAsync(Guid campaignId, string gmUserId)
+    {
+        var c = await _db.Campaigns.FindAsync(campaignId) ?? throw new InvalidOperationException("Campanha não encontrada");
+        if (c.OwnerUserId != gmUserId) throw new UnauthorizedAccessException("Apenas o GM pode ver membros.");
+        return await _db.CampaignMembers
+            .Where(m => m.CampaignId == campaignId && !m.IsBanned)
+            .OrderBy(m => m.JoinedAt)
+            .ToListAsync();
+    }
+
     public async Task RemoveMemberAsync(Guid campaignId, string targetUserId, string gmUserId, string? reason = null)
     {
         var c = await _db.Campaigns.FirstAsync(x => x.Id == campaignId);

--- a/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
@@ -50,6 +50,20 @@ public static class CampaignEndpoints
             return Results.Ok();
         });
 
+        g.MapGet("{id:guid}/join-requests", async (Guid id, ICampaignService svc, HttpContext http) =>
+        {
+            var userId = http.User.Identity!.Name!;
+            var list = await svc.ListJoinRequestsAsync(id, userId);
+            return Results.Ok(list);
+        });
+
+        g.MapGet("{id:guid}/members", async (Guid id, ICampaignService svc, HttpContext http) =>
+        {
+            var userId = http.User.Identity!.Name!;
+            var list = await svc.ListMembersAsync(id, userId);
+            return Results.Ok(list);
+        });
+
         g.MapDelete("{id:guid}/members/{targetUserId}", async (Guid id, string targetUserId, ICampaignService svc, HttpContext http, string? reason) =>
         {
             var userId = http.User.Identity!.Name!;

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -20,6 +20,37 @@ else
     {
         <button class="btn" @onclick="ToggleRecruitment">Alternar Recrutamento</button>
         <button class="btn" @onclick="FinalizeCampaign" style="margin-left:8px">Finalizar Campanha</button>
+
+        <h4>Solicitações Pendentes</h4>
+        @if (joinRequests.Count == 0)
+        {
+            <p>Nenhuma solicitação.</p>
+        }
+        else
+        {
+            @foreach (var r in joinRequests)
+            {
+                <div>@r.UserId (@r.Message)
+                    <button class="btn" @onclick="() => Approve(r.Id)">Aprovar</button>
+                    <button class="btn" @onclick="() => Reject(r.Id)" style="margin-left:4px">Rejeitar</button>
+                </div>
+            }
+        }
+
+        <h4>Membros</h4>
+        @if (members.Count == 0)
+        {
+            <p>Nenhum membro.</p>
+        }
+        else
+        {
+            @foreach (var m in members)
+            {
+                <div>@m.UserId
+                    <button class="btn" @onclick="() => Kick(m.UserId)" style="margin-left:4px">Remover</button>
+                </div>
+            }
+        }
     }
     else if (campaign.IsRecruiting)
     {
@@ -48,6 +79,8 @@ else
 
     Campaign? campaign;
     List<ChatMessageDto> messages = new();
+    List<JoinRequest> joinRequests = new();
+    List<CampaignMember> members = new();
     string message = string.Empty;
     string displayName = string.Empty;
     bool sentAsCharacter;
@@ -60,6 +93,11 @@ else
         campaign = await Http.GetFromJsonAsync<Campaign>($"/api/campaigns/{id}");
         await JS.InvokeVoidAsync("chat.join", id.ToString(), DotNetObjectReference.Create(this));
         await RefreshIsGm();
+        if (isGm)
+        {
+            await LoadJoinRequests();
+            await LoadMembers();
+        }
     }
 
     private async Task RefreshIsGm()
@@ -67,6 +105,16 @@ else
         var c = await Http.GetFromJsonAsync<Campaign>($"/api/campaigns/{id}");
         var me = (await AuthStateTask)!.User.Identity!.Name;
         isGm = c?.OwnerUserId == me;
+    }
+
+    private async Task LoadJoinRequests()
+    {
+        joinRequests = await Http.GetFromJsonAsync<List<JoinRequest>>($"/api/campaigns/{id}/join-requests") ?? new();
+    }
+
+    private async Task LoadMembers()
+    {
+        members = await Http.GetFromJsonAsync<List<CampaignMember>>($"/api/campaigns/{id}/members") ?? new();
     }
 
     [JSInvokable]
@@ -103,6 +151,28 @@ else
     {
         var res = await Http.PostAsJsonAsync($"/api/campaigns/{id}/join-requests", new { Message = "Gostaria de participar" });
         res.EnsureSuccessStatusCode();
+    }
+
+    private async Task Approve(Guid reqId)
+    {
+        var res = await Http.PutAsync($"/api/campaigns/{id}/join-requests/{reqId}/approve", null);
+        res.EnsureSuccessStatusCode();
+        await LoadJoinRequests();
+        await LoadMembers();
+    }
+
+    private async Task Reject(Guid reqId)
+    {
+        var res = await Http.PutAsync($"/api/campaigns/{id}/join-requests/{reqId}/reject", null);
+        res.EnsureSuccessStatusCode();
+        await LoadJoinRequests();
+    }
+
+    private async Task Kick(string userId)
+    {
+        var res = await Http.DeleteAsync($"/api/campaigns/{id}/members/{userId}");
+        res.EnsureSuccessStatusCode();
+        await LoadMembers();
     }
 
     private async Task Send()


### PR DESCRIPTION
## Summary
- expose endpoints to list join requests and members
- allow GMs to review join requests and remove members from campaign details page

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c97dcb8c83328d41d210cdcfe699