### PR TITLE
Add System namespaces to CampaignRulesTests

### DIFF
--- a/RpgRooms.Tests/CampaignRulesTests.cs
+++ b/RpgRooms.Tests/CampaignRulesTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using RpgRooms.Infrastructure.Services;
 using RpgRooms.Infrastructure.Data;


### PR DESCRIPTION
## Summary
- include System and System.Threading.Tasks in CampaignRulesTests

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e26900d8833298637fef14a9e76a