### PR TITLE
Add JSInterop using directive

### DIFF
--- a/RpgRooms.Web/Pages/_Imports.razor
+++ b/RpgRooms.Web/Pages/_Imports.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.JSInterop
 @using RpgRooms.Core.Domain.Entities
 @using RpgRooms.Core.Domain.Enums
 @using RpgRooms.Core.Application.DTOs


### PR DESCRIPTION
## Summary
- add Microsoft.JSInterop using to Blazor imports

## Testing
- ❌ `dotnet build` (dotnet command not found)

------
https://chatgpt.com/codex/tasks/task_e_68b0e468d7cc8332b2a8dd18d3fa0b56