### PR TITLE
Fix campaign ordering and add identity login partial

### DIFF
--- a/RpgRooms.Infrastructure/RpgRooms.Infrastructure.csproj
+++ b/RpgRooms.Infrastructure/RpgRooms.Infrastructure.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />

--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -159,7 +159,10 @@ public class CampaignService : ICampaignService
         if (recruitingOnly) q = q.Where(c => c.IsRecruiting);
         if (!string.IsNullOrWhiteSpace(ownerUserId)) q = q.Where(c => c.OwnerUserId == ownerUserId);
         if (!string.IsNullOrWhiteSpace(status) && Enum.TryParse<CampaignStatus>(status, out var st)) q = q.Where(c => c.Status == st);
-        return await q.OrderByDescending(c => c.CreatedAt).ToListAsync();
+
+        // SQLite does not support ordering by DateTimeOffset, so we order in-memory
+        var list = await q.ToListAsync();
+        return list.OrderByDescending(c => c.CreatedAt).ToList();
     }
 
     public Task<Campaign?> GetCampaignAsync(Guid campaignId) => _db.Campaigns.FirstOrDefaultAsync(c => c.Id == campaignId);

--- a/RpgRooms.Web/Pages/Shared/_LoginPartial.cshtml
+++ b/RpgRooms.Web/Pages/Shared/_LoginPartial.cshtml
@@ -1,0 +1,27 @@
+@using Microsoft.AspNetCore.Identity
+@using RpgRooms.Infrastructure.Data
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
+
+<ul class="navbar-nav">
+@if (SignInManager.IsSignedIn(User))
+{
+    <li class="nav-item">
+        <a class="nav-link" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">@User.Identity?.Name</a>
+    </li>
+    <li class="nav-item">
+        <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="/">
+            <button type="submit" class="nav-link btn btn-link">Logout</button>
+        </form>
+    </li>
+}
+else
+{
+    <li class="nav-item">
+        <a class="nav-link" asp-area="Identity" asp-page="/Account/Register">Register</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link" asp-area="Identity" asp-page="/Account/Login">Login</a>
+    </li>
+}
+</ul>

--- a/RpgRooms.Web/RpgRooms.Web.csproj
+++ b/RpgRooms.Web/RpgRooms.Web.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />


### PR DESCRIPTION
## Summary
- order campaigns in memory to avoid SQLite DateTimeOffset ordering errors
- add Identity `_LoginPartial` to satisfy default layout
- remove hardcoded runtime identifiers from projects for cross-platform builds

## Testing
- ❌ `dotnet test` *(command not found: dotnet)*
- ⚠️ `apt-get update` *(repository access failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f5a0857c8332a36686cb9770cb5f