### PR TITLE
Encaminhar cookies no HttpClient

### DIFF
--- a/RpgRooms.Web/Program.cs
+++ b/RpgRooms.Web/Program.cs
@@ -47,7 +47,11 @@ builder.Services.AddScoped(sp =>
     var accessor = sp.GetRequiredService<IHttpContextAccessor>();
     var req = accessor.HttpContext?.Request;
     var baseUri = req != null ? $"{req.Scheme}://{req.Host}{req.PathBase}/" : "http://localhost/";
-    return new HttpClient { BaseAddress = new Uri(baseUri) };
+    var client = new HttpClient { BaseAddress = new Uri(baseUri) };
+    // Encaminhar cookies de autenticação para chamadas à API
+    if (req?.Headers.TryGetValue("Cookie", out var cookie) == true)
+        client.DefaultRequestHeaders.Add("Cookie", new[] { cookie.ToString() });
+    return client;
 });
 
 builder.Services.AddScoped<IdentitySeeder>();


### PR DESCRIPTION
## Summary
- Encaminha cookies da requisição corrente ao `HttpClient`

## Testing
- `dotnet test` *(falhou: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f6f5b3288332ad24c2b1625deaf5