### PR TITLE
Order join requests and members in memory

### DIFF
--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -125,20 +125,20 @@ public class CampaignService : ICampaignService
     {
         var c = await _db.Campaigns.FindAsync(campaignId) ?? throw new InvalidOperationException("Campanha não encontrada");
         if (c.OwnerUserId != gmUserId) throw new UnauthorizedAccessException("Apenas o GM pode ver solicitações.");
-        return await _db.JoinRequests
+        var list = await _db.JoinRequests
             .Where(r => r.CampaignId == campaignId && r.Status == JoinRequestStatus.Pending)
-            .OrderBy(r => r.CreatedAt)
             .ToListAsync();
+        return list.OrderBy(r => r.CreatedAt).ToList();
     }
 
     public async Task<IReadOnlyList<CampaignMember>> ListMembersAsync(Guid campaignId, string gmUserId)
     {
         var c = await _db.Campaigns.FindAsync(campaignId) ?? throw new InvalidOperationException("Campanha não encontrada");
         if (c.OwnerUserId != gmUserId) throw new UnauthorizedAccessException("Apenas o GM pode ver membros.");
-        return await _db.CampaignMembers
+        var list = await _db.CampaignMembers
             .Where(m => m.CampaignId == campaignId && !m.IsBanned)
-            .OrderBy(m => m.JoinedAt)
             .ToListAsync();
+        return list.OrderBy(m => m.JoinedAt).ToList();
     }
 
     public async Task RemoveMemberAsync(Guid campaignId, string targetUserId, string gmUserId, string? reason = null)


### PR DESCRIPTION
## Summary
- Sort join request listing in memory for SQLite compatibility
- Sort member listing in memory after fetching from database

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fd4d57b48332b6b0bf144f6fa99b