### PR TITLE
Expose campaign chat history

### DIFF
--- a/RpgRooms.Core/Application/Interfaces/ICampaignService.cs
+++ b/RpgRooms.Core/Application/Interfaces/ICampaignService.cs
@@ -21,6 +21,7 @@ public interface ICampaignService
     Task<Campaign?> GetCampaignAsync(Guid campaignId);
 
     Task<ChatMessage> AddChatMessageAsync(Guid campaignId, string userId, string displayName, string content, bool sentAsCharacter);
+    Task<IReadOnlyList<ChatMessage>> ListChatMessagesAsync(Guid campaignId);
     Task<bool> IsMemberAsync(Guid campaignId, string userId);
     Task<bool> IsGmAsync(Guid campaignId, string userId);
     Task<int> CountMembersAsync(Guid campaignId);

--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -182,6 +182,15 @@ public class CampaignService : ICampaignService
         return msg;
     }
 
+    public async Task<IReadOnlyList<ChatMessage>> ListChatMessagesAsync(Guid campaignId)
+    {
+        var list = await _db.ChatMessages
+            .Where(m => m.CampaignId == campaignId)
+            .OrderBy(m => m.CreatedAt)
+            .ToListAsync();
+        return list;
+    }
+
     public Task<bool> IsMemberAsync(Guid campaignId, string userId) =>
         _db.CampaignMembers.AnyAsync(m => m.CampaignId == campaignId && m.UserId == userId);
 

--- a/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
@@ -1,4 +1,5 @@
 using RpgRooms.Core.Application.Interfaces;
+using RpgRooms.Core.Application.DTOs;
 
 namespace RpgRooms.Web.Endpoints;
 
@@ -62,6 +63,16 @@ public static class CampaignEndpoints
             var userId = http.User.Identity!.Name!;
             var list = await svc.ListMembersAsync(id, userId);
             return Results.Ok(list);
+        });
+
+        g.MapGet("{id:guid}/messages", async (Guid id, ICampaignService svc, HttpContext http) =>
+        {
+            var userId = http.User.Identity!.Name!;
+            if (!await svc.IsMemberAsync(id, userId) && !await svc.IsGmAsync(id, userId))
+                return Results.Forbid();
+            var list = await svc.ListChatMessagesAsync(id);
+            var dtos = list.Select(m => new ChatMessageDto(m.Id, m.DisplayName, m.Content, m.SentAsCharacter, m.CreatedAt));
+            return Results.Ok(dtos);
         });
 
         g.MapDelete("{id:guid}/members/{targetUserId}", async (Guid id, string targetUserId, ICampaignService svc, HttpContext http, string? reason) =>

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -91,6 +91,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         campaign = await Http.GetFromJsonAsync<Campaign>($"/api/campaigns/{id}");
+        messages = await Http.GetFromJsonAsync<List<ChatMessageDto>>($"/api/campaigns/{id}/messages") ?? new();
         await JS.InvokeVoidAsync("chat.join", id.ToString(), DotNetObjectReference.Create(this));
         await RefreshIsGm();
         if (isGm)


### PR DESCRIPTION
## Summary
- add service API to list campaign chat messages
- expose `GET /api/campaigns/{id}/messages` endpoint
- preload campaign chat history in details page before joining SignalR

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b10324f5a08332ba75b8b6469aae0a