### PR TITLE
Track connected users per campaign in chat hub

### DIFF
--- a/RpgRooms.Web/Hubs/CampaignChatHub.cs
+++ b/RpgRooms.Web/Hubs/CampaignChatHub.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using RpgRooms.Core.Application.Interfaces;
 using RpgRooms.Core.Application.DTOs;
+using System.Collections.Concurrent;
+using System.Linq;
 
 namespace RpgRooms.Web.Hubs;
 
@@ -11,6 +13,9 @@ public class CampaignChatHub : Hub
     private readonly ICampaignService _svc;
     public CampaignChatHub(ICampaignService svc) => _svc = svc;
 
+    private static readonly ConcurrentDictionary<Guid, HashSet<string>> _connectedUsers = new();
+    private static readonly ConcurrentDictionary<string, (Guid CampaignId, string UserId)> _connections = new();
+
     private static string GroupName(Guid campaignId) => $"campaign-{campaignId}";
 
     public async Task JoinCampaignGroup(Guid campaignId)
@@ -19,7 +24,18 @@ public class CampaignChatHub : Hub
         if (!await _svc.IsMemberAsync(campaignId, userId) && !await _svc.IsGmAsync(campaignId, userId))
             throw new HubException("Acesso negado ao chat desta campanha.");
         await Groups.AddToGroupAsync(Context.ConnectionId, GroupName(campaignId));
-        await Clients.Group(GroupName(campaignId)).SendAsync("SystemNotice", $"{userId} entrou no chat.");
+
+        _connections[Context.ConnectionId] = (campaignId, userId);
+
+        var users = _connectedUsers.GetOrAdd(campaignId, _ => new HashSet<string>());
+        bool isFirst;
+        lock (users)
+        {
+            isFirst = users.Add(userId);
+        }
+
+        if (isFirst)
+            await Clients.Group(GroupName(campaignId)).SendAsync("SystemNotice", $"{userId} entrou no chat.");
     }
 
     public async Task SendMessage(Guid campaignId, string displayName, string content, bool sentAsCharacter)
@@ -28,5 +44,30 @@ public class CampaignChatHub : Hub
         var msg = await _svc.AddChatMessageAsync(campaignId, userId, displayName, content, sentAsCharacter);
         var dto = new ChatMessageDto(msg.Id, msg.DisplayName, msg.Content, msg.SentAsCharacter, msg.CreatedAt);
         await Clients.Group(GroupName(campaignId)).SendAsync("ReceiveMessage", dto);
+    }
+
+    public override async Task OnDisconnectedAsync(Exception? exception)
+    {
+        if (_connections.TryRemove(Context.ConnectionId, out var info))
+        {
+            var (campaignId, userId) = info;
+            var remaining = _connections.Any(c => c.Value.CampaignId == campaignId && c.Value.UserId == userId);
+
+            if (!remaining && _connectedUsers.TryGetValue(campaignId, out var users))
+            {
+                bool removed;
+                lock (users)
+                {
+                    removed = users.Remove(userId);
+                    if (users.Count == 0)
+                        _connectedUsers.TryRemove(campaignId, out _);
+                }
+
+                if (removed)
+                    await Clients.Group(GroupName(campaignId)).SendAsync("SystemNotice", $"{userId} saiu do chat.");
+            }
+        }
+
+        await base.OnDisconnectedAsync(exception);
     }
 }


### PR DESCRIPTION
## Summary
- track connected users per campaign to avoid duplicate join notices
- remove users from tracking when disconnected

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b103e67a8883329ec3ec641a484f9e