### PR TITLE
Move chat join invocation to OnAfterRenderAsync

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -92,12 +92,19 @@ else
     {
         campaign = await Http.GetFromJsonAsync<Campaign>($"/api/campaigns/{id}");
         messages = await Http.GetFromJsonAsync<List<ChatMessageDto>>($"/api/campaigns/{id}/messages") ?? new();
-        await JS.InvokeVoidAsync("chat.join", id.ToString(), DotNetObjectReference.Create(this));
         await RefreshIsGm();
         if (isGm)
         {
             await LoadJoinRequests();
             await LoadMembers();
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("chat.join", id.ToString(), DotNetObjectReference.Create(this));
         }
     }
 


### PR DESCRIPTION
## Summary
- Load campaign chat data during initialization without JS interop
- Join chat hub on first render using OnAfterRenderAsync

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b105195bd483328a7a09a258d4896f