### PR TITLE
Remove CreatedAt from chat messages and DTO

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,7 @@ curl -X POST https://localhost:5001/api/campaigns ^
   "id": "GUID",
   "displayName": "Trevor Galhart",
   "content": "Ataque certeiro!",
-  "sentAsCharacter": true,
-  "createdAt": "2025-08-28T12:00:00Z"
+  "sentAsCharacter": true
 }
 ```
 

--- a/RpgRooms.Core/Application/DTOs/ChatMessageDto.cs
+++ b/RpgRooms.Core/Application/DTOs/ChatMessageDto.cs
@@ -1,3 +1,3 @@
 namespace RpgRooms.Core.Application.DTOs;
 
-public record ChatMessageDto(Guid Id, string DisplayName, string Content, bool SentAsCharacter, DateTimeOffset CreatedAt);
+public record ChatMessageDto(Guid Id, string DisplayName, string Content, bool SentAsCharacter);

--- a/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
@@ -71,7 +71,7 @@ public static class CampaignEndpoints
             if (!await svc.IsMemberAsync(id, userId) && !await svc.IsGmAsync(id, userId))
                 return Results.Forbid();
             var list = await svc.ListChatMessagesAsync(id);
-            var dtos = list.Select(m => new ChatMessageDto(m.Id, m.DisplayName, m.Content, m.SentAsCharacter, m.CreatedAt));
+            var dtos = list.Select(m => new ChatMessageDto(m.Id, m.DisplayName, m.Content, m.SentAsCharacter));
             return Results.Ok(dtos);
         });
 

--- a/RpgRooms.Web/Hubs/CampaignChatHub.cs
+++ b/RpgRooms.Web/Hubs/CampaignChatHub.cs
@@ -42,7 +42,7 @@ public class CampaignChatHub : Hub
     {
         var userId = Context.User!.Identity!.Name!;
         var msg = await _svc.AddChatMessageAsync(campaignId, userId, displayName, content, sentAsCharacter);
-        var dto = new ChatMessageDto(msg.Id, msg.DisplayName, msg.Content, msg.SentAsCharacter, msg.CreatedAt);
+        var dto = new ChatMessageDto(msg.Id, msg.DisplayName, msg.Content, msg.SentAsCharacter);
         await Clients.Group(GroupName(campaignId)).SendAsync("ReceiveMessage", dto);
     }
 

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -66,7 +66,7 @@ else
     <div class="chat-box">
         @foreach (var m in messages)
         {
-            <div><b>@m.DisplayName</b>: @m.Content <small>(@m.CreatedAt.LocalDateTime)</small></div>
+            <div><b>@m.DisplayName</b>: @m.Content</div>
         }
     </div>
 
@@ -136,7 +136,7 @@ else
     [JSInvokable]
     public Task OnSystemNotice(string text)
     {
-        messages.Add(new ChatMessageDto(Guid.Empty, "Sistema", text, false, DateTimeOffset.UtcNow));
+        messages.Add(new ChatMessageDto(Guid.Empty, "Sistema", text, false));
         StateHasChanged();
         return Task.CompletedTask;
     }


### PR DESCRIPTION
## Summary
- drop CreatedAt from chat message rendering
- simplify ChatMessageDto and usages to omit timestamp
- update chat API documentation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b105b450148332b84e37126401988a