### PR TITLE
Sort chat messages in memory

### DIFF
--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -184,11 +184,11 @@ public class CampaignService : ICampaignService
 
     public async Task<IReadOnlyList<ChatMessage>> ListChatMessagesAsync(Guid campaignId)
     {
+        // SQLite does not support ordering by DateTimeOffset, so we order in-memory
         var list = await _db.ChatMessages
             .Where(m => m.CampaignId == campaignId)
-            .OrderBy(m => m.CreatedAt)
             .ToListAsync();
-        return list;
+        return list.OrderBy(m => m.CreatedAt).ToList();
     }
 
     public Task<bool> IsMemberAsync(Guid campaignId, string userId) =>


### PR DESCRIPTION
## Summary
- Order chat messages in memory because SQLite cannot order by `DateTimeOffset`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b1090569e4833294587378695bd09d