### PR TITLE
Show all campaigns by default

### DIFF
--- a/RpgRooms.Web/Pages/Campaigns.razor
+++ b/RpgRooms.Web/Pages/Campaigns.razor
@@ -28,7 +28,7 @@
 
 @code {
     private string? search;
-    private bool recruitingOnly = true;
+    private bool recruitingOnly = false;
     private List<Campaign>? campaigns;
 
     protected override async Task OnInitializedAsync() => await Load();


### PR DESCRIPTION
## Summary
- Show all campaigns instead of only recruiting ones on campaigns page

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b10c1652208332a6792742b52b9087