### PR TITLE
Handle unauthorized access on campaign details

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -5,6 +5,8 @@
 @inject NavigationManager Nav
 @inject IJSRuntime JS
 @using RpgRooms.Core.Application.DTOs
+@using System.Net
+@using Microsoft.JSInterop
 
 <h3>@campaign?.Name</h3>
 @if (campaign is null)
@@ -90,8 +92,21 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        campaign = await Http.GetFromJsonAsync<Campaign>($"/api/campaigns/{id}");
-        messages = await Http.GetFromJsonAsync<List<ChatMessageDto>>($"/api/campaigns/{id}/messages") ?? new();
+        var campaignResponse = await Http.GetAsync($"/api/campaigns/{id}");
+        if (campaignResponse.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            Nav.NavigateTo($"/login?returnUrl=/campaigns/{id}", true);
+            return;
+        }
+        campaignResponse.EnsureSuccessStatusCode();
+        campaign = await campaignResponse.Content.ReadFromJsonAsync<Campaign>();
+
+        var messagesResponse = await Http.GetAsync($"/api/campaigns/{id}/messages");
+        if (messagesResponse.IsSuccessStatusCode)
+        {
+            messages = await messagesResponse.Content.ReadFromJsonAsync<List<ChatMessageDto>>() ?? new();
+        }
+
         await RefreshIsGm();
         if (isGm)
         {
@@ -104,7 +119,18 @@ else
     {
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("chat.join", id.ToString(), DotNetObjectReference.Create(this));
+            var user = (await AuthStateTask).User;
+            if (user.Identity?.IsAuthenticated == true)
+            {
+                try
+                {
+                    await JS.InvokeVoidAsync("chat.join", id.ToString(), DotNetObjectReference.Create(this));
+                }
+                catch (JSException)
+                {
+                    // Ignora falhas de conexão do SignalR
+                }
+            }
         }
     }
 

--- a/RpgRooms.Web/wwwroot/js/chat.js
+++ b/RpgRooms.Web/wwwroot/js/chat.js
@@ -10,9 +10,18 @@ window.chat = (function(){
       connection = new signalR.HubConnectionBuilder().withUrl('/hubs/campaign-chat').build();
       connection.on('ReceiveMessage', dto => dotnetObj && dotnetObj.invokeMethodAsync('OnReceiveMessage', dto));
       connection.on('SystemNotice', text => dotnetObj && dotnetObj.invokeMethodAsync('OnSystemNotice', text));
-      await connection.start();
+      try {
+        await connection.start();
+      } catch (err) {
+        console.error('Falha ao conectar ao SignalR', err);
+        return;
+      }
     }
-    await connection.invoke('JoinCampaignGroup', campaignId);
+    try {
+      await connection.invoke('JoinCampaignGroup', campaignId);
+    } catch (err) {
+      console.error('Falha ao entrar no grupo', err);
+    }
   }
   return {
     async join(campaignId, objRef){ dotnetObj = objRef; await ensure(campaignId); },


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users from campaign page before fetching data
- Guard SignalR chat connection behind auth check and handle JS errors
- Add defensive error handling in chat JavaScript for failed SignalR connections

## Testing
- ⚠️ `dotnet test` *(missing: dotnet command not found)*
- ⚠️ `apt-get update` *(missing: 403 Forbidden when accessing apt repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68b10f1f8b508332b5be81617c40e241