### PR TITLE
Prevent duplicate campaign creation

### DIFF
--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -16,6 +16,11 @@ public class CampaignService : ICampaignService
 
     public async Task<Campaign> CreateCampaignAsync(string ownerUserId, string name, string? description)
     {
+        var existing = await _db.Campaigns
+            .FirstOrDefaultAsync(c => c.OwnerUserId == ownerUserId && c.Name == name);
+        if (existing != null)
+            return existing;
+
         var c = new Campaign
         {
             OwnerUserId = ownerUserId,

--- a/RpgRooms.Tests/CampaignRulesTests.cs
+++ b/RpgRooms.Tests/CampaignRulesTests.cs
@@ -20,4 +20,16 @@ public class CampaignRulesTests
         await db.SaveChangesAsync();
         await Assert.ThrowsAsync<InvalidOperationException>(() => svc.CreateJoinRequestAsync(camp.Id, "u51", null));
     }
+
+    [Fact]
+    public async Task NaoCriaCampanhaDuplicada()
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("t2").Options;
+        var db = new AppDbContext(opts);
+        var svc = new CampaignService(db);
+        var camp1 = await svc.CreateCampaignAsync("gm", "A", "desc1");
+        var camp2 = await svc.CreateCampaignAsync("gm", "A", "desc2");
+        Assert.Equal(camp1.Id, camp2.Id);
+        Assert.Equal(1, await db.Campaigns.CountAsync());
+    }
 }


### PR DESCRIPTION
## Summary
- Avoid creating duplicate campaigns by checking existing entries by owner and name
- Add regression test ensuring duplicate creation returns the original campaign

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b19cf8dafc8332a6d09eb10e5b42fd