### PR TITLE
Use InProgress as default campaign status

### DIFF
--- a/RpgRooms.Core/Domain/Entities/Campaign.cs
+++ b/RpgRooms.Core/Domain/Entities/Campaign.cs
@@ -16,7 +16,7 @@ public class Campaign
     [Required]
     public string OwnerUserId { get; set; } = string.Empty; // GM
 
-    public CampaignStatus Status { get; set; } = CampaignStatus.Draft;
+    public CampaignStatus Status { get; set; } = CampaignStatus.InProgress;
     public bool IsRecruiting { get; set; } = false;
     public int MaxPlayers { get; set; } = 50; // regra fixa
 

--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -26,7 +26,7 @@ public class CampaignService : ICampaignService
             OwnerUserId = ownerUserId,
             Name = name,
             Description = description,
-            Status = CampaignStatus.Draft,
+            Status = CampaignStatus.InProgress,
             IsRecruiting = false,
             MaxPlayers = MAX_PLAYERS
         };
@@ -48,7 +48,7 @@ public class CampaignService : ICampaignService
             throw new InvalidOperationException("Campanha lotada (50/50).");
 
         c.IsRecruiting = !c.IsRecruiting;
-        if (c.IsRecruiting && c.Status == CampaignStatus.Draft)
+        if (c.IsRecruiting && c.Status == CampaignStatus.InProgress)
             c.Status = CampaignStatus.Recruiting;
         if (!c.IsRecruiting && c.Status == CampaignStatus.Recruiting && count > 0)
             c.Status = CampaignStatus.InProgress;

--- a/RpgRooms.Tests/CampaignRulesTests.cs
+++ b/RpgRooms.Tests/CampaignRulesTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using RpgRooms.Infrastructure.Services;
 using RpgRooms.Infrastructure.Data;
+using RpgRooms.Core.Domain.Enums;
 using Xunit;
 
 public class CampaignRulesTests
@@ -31,5 +32,15 @@ public class CampaignRulesTests
         var camp2 = await svc.CreateCampaignAsync("gm", "A", "desc2");
         Assert.Equal(camp1.Id, camp2.Id);
         Assert.Equal(1, await db.Campaigns.CountAsync());
+    }
+
+    [Fact]
+    public async Task StatusInicialEhInProgress()
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("t3").Options;
+        var db = new AppDbContext(opts);
+        var svc = new CampaignService(db);
+        var camp = await svc.CreateCampaignAsync("gm", "A", "B");
+        Assert.Equal(CampaignStatus.InProgress, camp.Status);
     }
 }


### PR DESCRIPTION
## Summary
- default campaigns to `InProgress`
- update service logic to honor new default
- add unit test for initial status

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a0fc13c08332a6114d8ea164921c