### PR TITLE
Allow campaigns to be ownerless after finalization

### DIFF
--- a/RpgRooms.Core/Domain/Entities/Campaign.cs
+++ b/RpgRooms.Core/Domain/Entities/Campaign.cs
@@ -13,8 +13,7 @@ public class Campaign
     [StringLength(1000)]
     public string? Description { get; set; }
 
-    [Required]
-    public string OwnerUserId { get; set; } = string.Empty; // GM
+    public string? OwnerUserId { get; set; } // GM
 
     public CampaignStatus Status { get; set; } = CampaignStatus.InProgress;
     public bool IsRecruiting { get; set; } = false;

--- a/RpgRooms.Infrastructure/Migrations/20240915000000_MakeOwnerUserIdNullable.cs
+++ b/RpgRooms.Infrastructure/Migrations/20240915000000_MakeOwnerUserIdNullable.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations;
+
+public partial class MakeOwnerUserIdNullable : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "OwnerUserId",
+            table: "Campaigns",
+            type: "TEXT",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "TEXT");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "OwnerUserId",
+            table: "Campaigns",
+            type: "TEXT",
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "TEXT",
+            oldNullable: true);
+    }
+}

--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -73,6 +73,7 @@ public class CampaignService : ICampaignService
         if (members.Any())
             _db.CampaignMembers.RemoveRange(members);
 
+        c.OwnerUserId = null;
         await _db.SaveChangesAsync();
 
         foreach (var m in members)
@@ -215,7 +216,7 @@ public class CampaignService : ICampaignService
     public async Task<bool> IsGmAsync(Guid campaignId, string userId)
     {
         var c = await _db.Campaigns.FindAsync(campaignId);
-        return c != null && c.OwnerUserId == userId;
+        return c != null && !string.IsNullOrEmpty(c.OwnerUserId) && c.OwnerUserId == userId;
     }
 
     public Task<int> CountMembersAsync(Guid campaignId) =>

--- a/RpgRooms.Tests/CampaignRulesTests.cs
+++ b/RpgRooms.Tests/CampaignRulesTests.cs
@@ -81,4 +81,16 @@ public class CampaignRulesTests
 
         Assert.Equal(0, await db.CampaignMembers.CountAsync(m => m.CampaignId == camp.Id));
     }
+
+    [Fact]
+    public async Task IsGmRetornaFalseAposFinalizar()
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("t6").Options;
+        var db = new AppDbContext(opts);
+        var svc = new CampaignService(db);
+        var camp = await svc.CreateCampaignAsync("gm", "A", null);
+        Assert.True(await svc.IsGmAsync(camp.Id, "gm"));
+        await svc.FinalizeCampaignAsync(camp.Id, "gm");
+        Assert.False(await svc.IsGmAsync(camp.Id, "gm"));
+    }
 }

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -191,6 +191,7 @@ else
         var res = await Http.PutAsync($"/api/campaigns/{id}/finalize", null);
         res.EnsureSuccessStatusCode();
         campaign = await Http.GetFromJsonAsync<Campaign>($"/api/campaigns/{id}");
+        await RefreshIsGm();
     }
 
     private async Task SendJoinRequest()


### PR DESCRIPTION
## Summary
- Allow campaigns to have null owners and add migration
- Null out OwnerUserId when finalizing and adjust GM checks
- Refresh GM status on campaign finalization and cover with tests

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet ef database update -p RpgRooms.Infrastructure -s RpgRooms.Web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b4f226dc83329f5afd1c69fc5f76