### PR TITLE
Fix antiforgery token retrieval in login partial

### DIFF
--- a/RpgRooms.Web/Pages/Shared/_LoginPartial.cshtml
+++ b/RpgRooms.Web/Pages/Shared/_LoginPartial.cshtml
@@ -4,7 +4,9 @@
 @inject UserManager<ApplicationUser> UserManager
 @inject Microsoft.AspNetCore.Antiforgery.IAntiforgery AntiForgery
 @{
-    var tokens = AntiForgery.GetAndStoreTokens(HttpContext);
+    // Use the current HTTP context exposed via the Razor Page's Context property
+    // instead of referring to the HttpContext type directly.
+    var tokens = AntiForgery.GetAndStoreTokens(Context);
 }
 
 <ul class="navbar-nav">


### PR DESCRIPTION
## Summary
- Use Razor Page context when generating antiforgery tokens

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f0b0a0788332b1fb9bfef39fc149