### PR TITLE
Persist join-notification state for campaign chat

### DIFF
--- a/RpgRooms.Core/Domain/Entities/CampaignMember.cs
+++ b/RpgRooms.Core/Domain/Entities/CampaignMember.cs
@@ -8,4 +8,5 @@ public class CampaignMember
     public string? CharacterName { get; set; }
     public DateTimeOffset JoinedAt { get; set; } = DateTimeOffset.UtcNow;
     public bool IsBanned { get; set; } = false;
+    public bool HasJoinNotice { get; set; } = false;
 }

--- a/RpgRooms.Infrastructure/Migrations/20240925000000_AddHasJoinNotice.cs
+++ b/RpgRooms.Infrastructure/Migrations/20240925000000_AddHasJoinNotice.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations;
+
+public partial class AddHasJoinNotice : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<bool>(
+            name: "HasJoinNotice",
+            table: "CampaignMembers",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: false);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "HasJoinNotice",
+            table: "CampaignMembers");
+    }
+}

--- a/RpgRooms.Tests/CampaignChatHubTests.cs
+++ b/RpgRooms.Tests/CampaignChatHubTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using RpgRooms.Infrastructure.Data;
+using RpgRooms.Infrastructure.Services;
+using RpgRooms.Web.Hubs;
+using Xunit;
+
+public class CampaignChatHubTests
+{
+    [Fact]
+    public async Task JoinCampaignGroup_EmitsNoticeOnce()
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("hubtest").Options;
+        var db = new AppDbContext(opts);
+        var svc = new CampaignService(db);
+        var camp = await svc.CreateCampaignAsync("gm", "C", null);
+        db.CampaignMembers.Add(new() { CampaignId = camp.Id, UserId = "u1" });
+        await db.SaveChangesAsync();
+
+        var hub = new CampaignChatHub(svc, db)
+        {
+            Clients = new TestHubCallerClients(),
+            Groups = new TestGroupManager(),
+            Context = new TestHubCallerContext("c1", "u1")
+        };
+
+        await hub.JoinCampaignGroup(camp.Id);
+        await hub.JoinCampaignGroup(camp.Id);
+
+        var proxy = (TestClientProxy)((TestHubCallerClients)hub.Clients).GroupProxy;
+        var notices = proxy.Sent.Count(s => s.method == "SystemNotice");
+        Assert.Equal(1, notices);
+    }
+}
+
+class TestGroupManager : IGroupManager
+{
+    public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+    public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default) => Task.CompletedTask;
+}
+
+class TestClientProxy : IClientProxy
+{
+    public List<(string method, object?[] args)> Sent { get; } = new();
+    public Task SendCoreAsync(string method, object?[] args, CancellationToken cancellationToken = default)
+    {
+        Sent.Add((method, args));
+        return Task.CompletedTask;
+    }
+}
+
+class TestHubCallerClients : IHubCallerClients
+{
+    public IClientProxy GroupProxy { get; } = new TestClientProxy();
+    public IClientProxy All => GroupProxy;
+    public IClientProxy AllExcept(IReadOnlyList<string> excludedConnectionIds) => GroupProxy;
+    public IClientProxy Client(string connectionId) => GroupProxy;
+    public IClientProxy Clients(IReadOnlyList<string> connectionIds) => GroupProxy;
+    public IClientProxy Group(string groupName) => GroupProxy;
+    public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excludedConnectionIds) => GroupProxy;
+    public IClientProxy Groups(IReadOnlyList<string> groupNames) => GroupProxy;
+    public IClientProxy User(string userId) => GroupProxy;
+    public IClientProxy Users(IReadOnlyList<string> userIds) => GroupProxy;
+}
+
+class TestHubCallerContext : HubCallerContext
+{
+    public override string ConnectionId { get; }
+    public override string? UserIdentifier => User.Identity?.Name;
+    public override ClaimsPrincipal User { get; }
+    public override IDictionary<object, object?> Items { get; set; } = new Dictionary<object, object?>();
+    public override IFeatureCollection Features { get; } = new FeatureCollection();
+    public override CancellationToken ConnectionAborted { get; } = CancellationToken.None;
+    public override void Abort() { }
+    public override HttpContext? GetHttpContext() => null;
+
+    public TestHubCallerContext(string connectionId, string userId)
+    {
+        ConnectionId = connectionId;
+        User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, userId) }));
+    }
+}

--- a/RpgRooms.Tests/RpgRooms.Tests.csproj
+++ b/RpgRooms.Tests/RpgRooms.Tests.csproj
@@ -13,5 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="..\RpgRooms.Core\RpgRooms.Core.csproj" />
     <ProjectReference Include="..\RpgRooms.Infrastructure\RpgRooms.Infrastructure.csproj" />
+    <ProjectReference Include="..\RpgRooms.Web\RpgRooms.Web.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- track whether a campaign member has already triggered a join notice
- send chat system notice only on first join and persist state
- verify duplicate joins produce just a single notice

## Testing
- `dotnet ef database update` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fb02ee6883328cb9b7b968fb5e76