### PR TITLE
Join chat on initialization and clean up object reference

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -8,6 +8,7 @@
 @using RpgRooms.Core.Domain.Enums
 @using System.Net
 @using Microsoft.JSInterop
+@implements IAsyncDisposable
 
 <h3>@campaign?.Name</h3>
 @if (loadFailed)
@@ -119,6 +120,7 @@ else
     bool isGm;
     bool isMember;
     bool loadFailed;
+    DotNetObjectReference<CampaignDetails>? _objRef;
 
     [CascadingParameter] public Task<AuthenticationState> AuthStateTask { get; set; } = default!;
 
@@ -174,29 +176,24 @@ else
                     }
                 }
             }
-        }
-        catch
-        {
-            loadFailed = true;
-        }
-    }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
             var user = (await AuthStateTask).User;
             if (user.Identity?.IsAuthenticated == true && (isGm || isMember))
             {
                 try
                 {
-                    await JS.InvokeVoidAsync("chat.join", id.ToString(), DotNetObjectReference.Create(this));
+                    _objRef = DotNetObjectReference.Create(this);
+                    await JS.InvokeVoidAsync("chat.join", id.ToString(), _objRef);
                 }
                 catch (JSException)
                 {
                     // Ignora falhas de conexão do SignalR
                 }
             }
+        }
+        catch
+        {
+            loadFailed = true;
         }
     }
 
@@ -302,5 +299,22 @@ else
     private async Task HandleKey(KeyboardEventArgs e)
     {
         if (e.Key == "Enter") await Send();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_objRef is not null)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("chat.leave", id.ToString());
+            }
+            catch (JSException)
+            {
+                // Ignora falhas de conexão do SignalR
+            }
+
+            _objRef.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Join campaign chat during initialization using a reusable DotNetObjectReference
- Dispose of the chat reference on component teardown and notify JS to leave

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2113f24dc83329f7d781711bb9e91