### PR TITLE
Add chat leave helper and persist interop reference

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -120,7 +120,7 @@ else
     bool isGm;
     bool isMember;
     bool loadFailed;
-    DotNetObjectReference<CampaignDetails>? _objRef;
+    private DotNetObjectReference<CampaignDetails>? _objRef;
 
     [CascadingParameter] public Task<AuthenticationState> AuthStateTask { get; set; } = default!;
 
@@ -315,6 +315,7 @@ else
             }
 
             _objRef.Dispose();
+            _objRef = null;
         }
     }
 }

--- a/RpgRooms.Web/wwwroot/js/chat.js
+++ b/RpgRooms.Web/wwwroot/js/chat.js
@@ -30,11 +30,23 @@ window.chat = (function(){
     }
   }
   return {
-    async join(campaignId, objRef){ dotnetObj = objRef; await ensure(campaignId); },
-    async send(campaignId, displayName, content, sentAsCharacter){
-      await ensure(campaignId);
-      await connection.invoke('SendMessage', campaignId, displayName, content, sentAsCharacter);
+      async join(campaignId, objRef){ dotnetObj = objRef; await ensure(campaignId); },
+      async send(campaignId, displayName, content, sentAsCharacter){
+        await ensure(campaignId);
+        await connection.invoke('SendMessage', campaignId, displayName, content, sentAsCharacter);
+      },
+      async leave(){
+        dotnetObj = null;
+        currentCampaignId = null;
+        if(connection){
+          try {
+            await connection.stop();
+          } catch (err) {
+            console.error('Falha ao desconectar do SignalR', err);
+          }
+          connection = null;
+        }
+      }
     }
-  }
-})();
+  })();
 


### PR DESCRIPTION
## Summary
- keep chat interop `_objRef` on the component and dispose it on teardown
- add `chat.leave` helper that stops SignalR connection and clears the .NET reference

## Testing
- ⚠️ `dotnet test` *(missing `dotnet` command)*
- ⚠️ `apt-get update` *(403 error)*
- ⚠️ `apt-get install -y dotnet-sdk-9.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2133589e483329b8dbcaa203f37d8