### PR TITLE
Track campaign exits and cooldown rejoin requests

### DIFF
--- a/RpgRooms.Core/Domain/Entities/CampaignExit.cs
+++ b/RpgRooms.Core/Domain/Entities/CampaignExit.cs
@@ -1,0 +1,10 @@
+namespace RpgRooms.Core.Domain.Entities;
+
+public class CampaignExit
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CampaignId { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public DateTimeOffset ExitedAt { get; set; } = DateTimeOffset.UtcNow;
+    public bool IsKick { get; set; } = false;
+}

--- a/RpgRooms.Infrastructure/Data/AppDbContext.cs
+++ b/RpgRooms.Infrastructure/Data/AppDbContext.cs
@@ -19,6 +19,7 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<JoinRequest> JoinRequests => Set<JoinRequest>();
     public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
     public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
+    public DbSet<CampaignExit> CampaignExits => Set<CampaignExit>();
 
     protected override void OnModelCreating(ModelBuilder b)
     {

--- a/RpgRooms.Infrastructure/Migrations/20241010000000_AddCampaignExit.cs
+++ b/RpgRooms.Infrastructure/Migrations/20241010000000_AddCampaignExit.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations;
+
+public partial class AddCampaignExit : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "CampaignExits",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                CampaignId = table.Column<Guid>(type: "TEXT", nullable: false),
+                UserId = table.Column<string>(type: "TEXT", nullable: false),
+                ExitedAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                IsKick = table.Column<bool>(type: "INTEGER", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_CampaignExits", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_CampaignExits_CampaignId_UserId",
+            table: "CampaignExits",
+            columns: new[] { "CampaignId", "UserId" });
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "CampaignExits");
+    }
+}


### PR DESCRIPTION
## Summary
- add `CampaignExit` entity and migration
- record exits when members leave or are removed
- block rejoin requests within 12h and add unit tests

## Testing
- `dotnet test` *(fails: dotnet: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b217c0622c8332b5d27dd71676ca47