### PR TITLE
Add Character entity and EF Core migration

### DIFF
--- a/RpgRooms.Core/Domain/Entities/Character.cs
+++ b/RpgRooms.Core/Domain/Entities/Character.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace RpgRooms.Core.Domain.Entities;
+
+public class Character
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    // Identification
+    [Required, StringLength(80, MinimumLength = 3)]
+    public string Name { get; set; } = string.Empty;
+    [StringLength(40)]
+    public string? Race { get; set; }
+    [StringLength(40)]
+    public string? Class { get; set; }
+    public int Level { get; set; } = 1;
+    [StringLength(100)]
+    public string? Background { get; set; }
+    [StringLength(40)]
+    public string? Alignment { get; set; }
+    public int XP { get; set; }
+
+    // Attributes
+    public int Str { get; set; }
+    public int Dex { get; set; }
+    public int Con { get; set; }
+    public int Int { get; set; }
+    public int Wis { get; set; }
+    public int Cha { get; set; }
+
+    // Relationships
+    public Guid CampaignId { get; set; }
+    public string UserId { get; set; } = string.Empty;
+
+    // Aggregates
+    public ICollection<SavingThrowProficiency> SavingThrowProficiencies { get; set; } = new List<SavingThrowProficiency>();
+    public ICollection<SkillProficiency> SkillProficiencies { get; set; } = new List<SkillProficiency>();
+    public ICollection<InventoryItem> Inventory { get; set; } = new List<InventoryItem>();
+    public ICollection<Spell> Spells { get; set; } = new List<Spell>();
+}
+
+public class SavingThrowProficiency
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CharacterId { get; set; }
+    [Required, StringLength(40)]
+    public string Name { get; set; } = string.Empty;
+}
+
+public class SkillProficiency
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CharacterId { get; set; }
+    [Required, StringLength(40)]
+    public string Name { get; set; } = string.Empty;
+}
+
+public class InventoryItem
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CharacterId { get; set; }
+    [Required, StringLength(80)]
+    public string Name { get; set; } = string.Empty;
+}
+
+public class Spell
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid CharacterId { get; set; }
+    [Required, StringLength(80)]
+    public string Name { get; set; } = string.Empty;
+}

--- a/RpgRooms.Infrastructure/Data/AppDbContext.cs
+++ b/RpgRooms.Infrastructure/Data/AppDbContext.cs
@@ -20,11 +20,46 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
     public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
     public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
     public DbSet<CampaignExit> CampaignExits => Set<CampaignExit>();
+    public DbSet<Character> Characters => Set<Character>();
+    public DbSet<SavingThrowProficiency> SavingThrowProficiencies => Set<SavingThrowProficiency>();
+    public DbSet<SkillProficiency> SkillProficiencies => Set<SkillProficiency>();
+    public DbSet<InventoryItem> InventoryItems => Set<InventoryItem>();
+    public DbSet<Spell> Spells => Set<Spell>();
 
     protected override void OnModelCreating(ModelBuilder b)
     {
         base.OnModelCreating(b);
         b.Entity<CampaignMember>().HasIndex(m => new { m.CampaignId, m.UserId }).IsUnique();
         b.Entity<Campaign>().Property(c => c.MaxPlayers).HasDefaultValue(50);
+
+        b.Entity<Character>()
+            .HasOne<Campaign>()
+            .WithMany()
+            .HasForeignKey(c => c.CampaignId);
+
+        b.Entity<Character>()
+            .HasOne<ApplicationUser>()
+            .WithMany()
+            .HasForeignKey(c => c.UserId);
+
+        b.Entity<SavingThrowProficiency>()
+            .HasOne<Character>()
+            .WithMany(c => c.SavingThrowProficiencies)
+            .HasForeignKey(p => p.CharacterId);
+
+        b.Entity<SkillProficiency>()
+            .HasOne<Character>()
+            .WithMany(c => c.SkillProficiencies)
+            .HasForeignKey(p => p.CharacterId);
+
+        b.Entity<InventoryItem>()
+            .HasOne<Character>()
+            .WithMany(c => c.Inventory)
+            .HasForeignKey(i => i.CharacterId);
+
+        b.Entity<Spell>()
+            .HasOne<Character>()
+            .WithMany(c => c.Spells)
+            .HasForeignKey(s => s.CharacterId);
     }
 }

--- a/RpgRooms.Infrastructure/Migrations/20241020000000_AddCharacter.cs
+++ b/RpgRooms.Infrastructure/Migrations/20241020000000_AddCharacter.cs
@@ -1,0 +1,173 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations;
+
+public partial class AddCharacter : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "Characters",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                CampaignId = table.Column<Guid>(type: "TEXT", nullable: false),
+                UserId = table.Column<string>(type: "TEXT", nullable: false),
+                Name = table.Column<string>(type: "TEXT", nullable: false),
+                Race = table.Column<string>(type: "TEXT", nullable: true),
+                Class = table.Column<string>(type: "TEXT", nullable: true),
+                Level = table.Column<int>(type: "INTEGER", nullable: false),
+                Background = table.Column<string>(type: "TEXT", nullable: true),
+                Alignment = table.Column<string>(type: "TEXT", nullable: true),
+                XP = table.Column<int>(type: "INTEGER", nullable: false),
+                Str = table.Column<int>(type: "INTEGER", nullable: false),
+                Dex = table.Column<int>(type: "INTEGER", nullable: false),
+                Con = table.Column<int>(type: "INTEGER", nullable: false),
+                Int = table.Column<int>(type: "INTEGER", nullable: false),
+                Wis = table.Column<int>(type: "INTEGER", nullable: false),
+                Cha = table.Column<int>(type: "INTEGER", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Characters", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Characters_Campaigns_CampaignId",
+                    column: x => x.CampaignId,
+                    principalTable: "Campaigns",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_Characters_AspNetUsers_UserId",
+                    column: x => x.UserId,
+                    principalTable: "AspNetUsers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "InventoryItems",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                CharacterId = table.Column<Guid>(type: "TEXT", nullable: false),
+                Name = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_InventoryItems", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_InventoryItems_Characters_CharacterId",
+                    column: x => x.CharacterId,
+                    principalTable: "Characters",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "SavingThrowProficiencies",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                CharacterId = table.Column<Guid>(type: "TEXT", nullable: false),
+                Name = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_SavingThrowProficiencies", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_SavingThrowProficiencies_Characters_CharacterId",
+                    column: x => x.CharacterId,
+                    principalTable: "Characters",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "SkillProficiencies",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                CharacterId = table.Column<Guid>(type: "TEXT", nullable: false),
+                Name = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_SkillProficiencies", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_SkillProficiencies_Characters_CharacterId",
+                    column: x => x.CharacterId,
+                    principalTable: "Characters",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "Spells",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                CharacterId = table.Column<Guid>(type: "TEXT", nullable: false),
+                Name = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_Spells", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_Spells_Characters_CharacterId",
+                    column: x => x.CharacterId,
+                    principalTable: "Characters",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Characters_CampaignId",
+            table: "Characters",
+            column: "CampaignId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Characters_UserId",
+            table: "Characters",
+            column: "UserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_InventoryItems_CharacterId",
+            table: "InventoryItems",
+            column: "CharacterId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_SavingThrowProficiencies_CharacterId",
+            table: "SavingThrowProficiencies",
+            column: "CharacterId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_SkillProficiencies_CharacterId",
+            table: "SkillProficiencies",
+            column: "CharacterId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_Spells_CharacterId",
+            table: "Spells",
+            column: "CharacterId");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "InventoryItems");
+
+        migrationBuilder.DropTable(
+            name: "SavingThrowProficiencies");
+
+        migrationBuilder.DropTable(
+            name: "SkillProficiencies");
+
+        migrationBuilder.DropTable(
+            name: "Spells");
+
+        migrationBuilder.DropTable(
+            name: "Characters");
+    }
+}


### PR DESCRIPTION
## Summary
- add Character domain entity with ability scores, proficiencies, inventory and spell collections
- wire up Character and related aggregates to AppDbContext
- include initial EF Core migration for Character and related tables

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b21baf8ba4833281fe44948e224a34