### PR TITLE
Add character endpoints and auto-create sheet on join approval

### DIFF
--- a/RpgRooms.Core/Application/Interfaces/ICharacterService.cs
+++ b/RpgRooms.Core/Application/Interfaces/ICharacterService.cs
@@ -10,4 +10,5 @@ public interface ICharacterService
     Task<CharacterSheetDto> CreateCharacterAsync(Character character);
     Task<CharacterSheetDto> UpdateCharacterAsync(Guid id, Character character, string userId);
     Task<CharacterSheetDto?> GetCharacterAsync(Guid id);
+    Task DeleteCharacterAsync(Guid id, string userId);
 }

--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -118,6 +118,19 @@ public class CampaignService : ICampaignService
         req.Status = JoinRequestStatus.Approved;
         req.DecisionAt = DateTimeOffset.UtcNow;
         _db.CampaignMembers.Add(new CampaignMember { CampaignId = campaignId, UserId = req.UserId });
+        _db.Characters.Add(new Character
+        {
+            CampaignId = campaignId,
+            UserId = req.UserId,
+            Name = "New Character",
+            Level = 1,
+            Str = 10,
+            Dex = 10,
+            Con = 10,
+            Int = 10,
+            Wis = 10,
+            Cha = 10
+        });
         await _db.SaveChangesAsync();
         await Audit("ApproveJoin", gmUserId, campaignId, new { req.UserId });
 

--- a/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
@@ -1,0 +1,64 @@
+using Microsoft.AspNetCore.Authorization;
+using RpgRooms.Core.Application.Interfaces;
+using RpgRooms.Core.Domain.Entities;
+using RpgRooms.Core.Security;
+
+namespace RpgRooms.Web.Endpoints;
+
+public static class CharacterEndpoints
+{
+    public static IEndpointRouteBuilder MapCharacterEndpoints(this IEndpointRouteBuilder app)
+    {
+        var g = app.MapGroup("/api/campaigns/{id:guid}/characters").RequireAuthorization();
+
+        g.MapGet("{charId:guid}", async (Guid id, Guid charId, ICharacterService charSvc, IAuthorizationService auth, HttpContext http) =>
+        {
+            var userId = http.User.Identity!.Name!;
+            var sheet = await charSvc.GetCharacterAsync(charId);
+            if (sheet is null || sheet.Character.CampaignId != id)
+                return Results.NotFound();
+            var isOwner = sheet.Character.UserId == userId;
+            var isGm = (await auth.AuthorizeAsync(http.User, null, Policies.IsGmOfCampaign)).Succeeded;
+            if (!isOwner && !isGm)
+                return Results.Forbid();
+            return Results.Ok(sheet);
+        });
+
+        g.MapPost("", async (Guid id, Character character, ICharacterService charSvc, ICampaignService campSvc, IAuthorizationService auth, HttpContext http) =>
+        {
+            var userId = http.User.Identity!.Name!;
+            var isGm = (await auth.AuthorizeAsync(http.User, null, Policies.IsGmOfCampaign)).Succeeded;
+            if (!isGm && !await campSvc.IsMemberAsync(id, userId))
+                return Results.Forbid();
+            character.UserId = userId;
+            character.CampaignId = id;
+            var sheet = await charSvc.CreateCharacterAsync(character);
+            return Results.Ok(sheet);
+        });
+
+        g.MapPut("{charId:guid}", async (Guid id, Guid charId, Character character, ICharacterService charSvc, HttpContext http) =>
+        {
+            var userId = http.User.Identity!.Name!;
+            var sheet = await charSvc.UpdateCharacterAsync(charId, character, userId);
+            if (sheet.Character.CampaignId != id)
+                return Results.BadRequest();
+            return Results.Ok(sheet);
+        });
+
+        g.MapDelete("{charId:guid}", async (Guid id, Guid charId, ICharacterService charSvc, IAuthorizationService auth, HttpContext http) =>
+        {
+            var userId = http.User.Identity!.Name!;
+            var sheet = await charSvc.GetCharacterAsync(charId);
+            if (sheet is null || sheet.Character.CampaignId != id)
+                return Results.NotFound();
+            var isOwner = sheet.Character.UserId == userId;
+            var isGm = (await auth.AuthorizeAsync(http.User, null, Policies.IsGmOfCampaign)).Succeeded;
+            if (!isOwner && !isGm)
+                return Results.Forbid();
+            await charSvc.DeleteCharacterAsync(charId, userId);
+            return Results.Ok();
+        });
+
+        return app;
+    }
+}

--- a/RpgRooms.Web/Program.cs
+++ b/RpgRooms.Web/Program.cs
@@ -82,6 +82,7 @@ app.MapHub<CampaignChatHub>("/hubs/campaign-chat");
 
 // Minimal APIs
 app.MapCampaignEndpoints();
+app.MapCharacterEndpoints();
 
 app.MapFallbackToPage("/_Host");
 


### PR DESCRIPTION
## Summary
- add CRUD minimal APIs for characters with GM/owner authorization
- allow campaign join approvals to generate blank character sheets
- enable character deletion and wire up endpoint routing

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b21da8b1c083328cea8807eff21aca