### PR TITLE
Add character sheet and editor with RPG-themed sections

### DIFF
--- a/RpgRooms.Web/Pages/CharacterEdit.razor
+++ b/RpgRooms.Web/Pages/CharacterEdit.razor
@@ -1,0 +1,27 @@
+@page "/characters/edit"
+<h3>Editar Personagem</h3>
+<div class="rpg-sheet page">
+    <IdentificationSection Character="character" />
+    <AttributesSection Character="character" />
+    <SavingThrowsSection Character="character" ProficiencyBonus="ProficiencyBonus" />
+    <SkillsSection Character="character" ProficiencyBonus="ProficiencyBonus" />
+    <AttacksSection Character="character" />
+    <InventorySection Character="character" />
+    <DescriptionSection Character="character" />
+</div>
+
+@code {
+    Character character = new()
+    {
+        Name = "Novo Herói",
+        Level = 1,
+        Str = 10,
+        Dex = 10,
+        Con = 10,
+        Int = 10,
+        Wis = 10,
+        Cha = 10
+    };
+
+    int ProficiencyBonus => ((character.Level - 1) / 4) + 2;
+}

--- a/RpgRooms.Web/Pages/CharacterSheet.razor
+++ b/RpgRooms.Web/Pages/CharacterSheet.razor
@@ -1,0 +1,31 @@
+@page "/characters/sheet"
+<h3>Ficha de Personagem</h3>
+<div class="rpg-sheet page">
+    <IdentificationSection Character="character" IsReadOnly="true" />
+    <AttributesSection Character="character" IsReadOnly="true" />
+    <SavingThrowsSection Character="character" ProficiencyBonus="ProficiencyBonus" IsReadOnly="true" />
+    <SkillsSection Character="character" ProficiencyBonus="ProficiencyBonus" IsReadOnly="true" />
+    <AttacksSection Character="character" IsReadOnly="true" />
+    <InventorySection Character="character" IsReadOnly="true" />
+    <DescriptionSection Character="character" IsReadOnly="true" />
+</div>
+
+@code {
+    Character character = new()
+    {
+        Name = "Herói",
+        Race = "Humano",
+        Class = "Guerreiro",
+        Level = 1,
+        Alignment = "ND",
+        Background = "Um guerreiro corajoso.",
+        Str = 15,
+        Dex = 12,
+        Con = 14,
+        Int = 10,
+        Wis = 13,
+        Cha = 8
+    };
+
+    int ProficiencyBonus => ((character.Level - 1) / 4) + 2;
+}

--- a/RpgRooms.Web/Pages/Characters/AttacksSection.razor
+++ b/RpgRooms.Web/Pages/Characters/AttacksSection.razor
@@ -1,0 +1,30 @@
+@using RpgRooms.Core.Domain.Entities
+<div class="rpg-section">
+  <h4>Ataques/Magias</h4>
+  <ul>
+    @foreach(var s in Character.Spells)
+    {
+        <li>@s.Name</li>
+    }
+  </ul>
+  @if(!IsReadOnly)
+  {
+      <input class="rpg-input" @bind="newSpell" placeholder="Novo ataque ou magia" />
+      <button class="btn" @onclick="Add">Adicionar</button>
+  }
+</div>
+
+@code {
+  [Parameter] public Character Character { get; set; } = default!;
+  [Parameter] public bool IsReadOnly { get; set; }
+
+  string newSpell = string.Empty;
+  void Add()
+  {
+      if(!string.IsNullOrWhiteSpace(newSpell))
+      {
+          Character.Spells.Add(new Spell { Name = newSpell });
+          newSpell = string.Empty;
+      }
+  }
+}

--- a/RpgRooms.Web/Pages/Characters/AttributesSection.razor
+++ b/RpgRooms.Web/Pages/Characters/AttributesSection.razor
@@ -1,0 +1,65 @@
+@using RpgRooms.Core.Domain.Entities
+<div class="rpg-section">
+  <h4>Atributos</h4>
+  <div>
+    <label>Força:</label>
+    @if(!IsReadOnly)
+    {
+        <input type="number" class="rpg-input" @bind="Character.Str" />
+    }
+    else { <span>@Character.Str</span> }
+    <span>Mod: @GetMod(Character.Str)</span>
+  </div>
+  <div>
+    <label>Destreza:</label>
+    @if(!IsReadOnly)
+    {
+        <input type="number" class="rpg-input" @bind="Character.Dex" />
+    }
+    else { <span>@Character.Dex</span> }
+    <span>Mod: @GetMod(Character.Dex)</span>
+  </div>
+  <div>
+    <label>Constituição:</label>
+    @if(!IsReadOnly)
+    {
+        <input type="number" class="rpg-input" @bind="Character.Con" />
+    }
+    else { <span>@Character.Con</span> }
+    <span>Mod: @GetMod(Character.Con)</span>
+  </div>
+  <div>
+    <label>Inteligência:</label>
+    @if(!IsReadOnly)
+    {
+        <input type="number" class="rpg-input" @bind="Character.Int" />
+    }
+    else { <span>@Character.Int</span> }
+    <span>Mod: @GetMod(Character.Int)</span>
+  </div>
+  <div>
+    <label>Sabedoria:</label>
+    @if(!IsReadOnly)
+    {
+        <input type="number" class="rpg-input" @bind="Character.Wis" />
+    }
+    else { <span>@Character.Wis</span> }
+    <span>Mod: @GetMod(Character.Wis)</span>
+  </div>
+  <div>
+    <label>Carisma:</label>
+    @if(!IsReadOnly)
+    {
+        <input type="number" class="rpg-input" @bind="Character.Cha" />
+    }
+    else { <span>@Character.Cha</span> }
+    <span>Mod: @GetMod(Character.Cha)</span>
+  </div>
+</div>
+
+@code {
+  [Parameter] public Character Character { get; set; } = default!;
+  [Parameter] public bool IsReadOnly { get; set; }
+
+  int GetMod(int score) => (score - 10) / 2;
+}

--- a/RpgRooms.Web/Pages/Characters/DescriptionSection.razor
+++ b/RpgRooms.Web/Pages/Characters/DescriptionSection.razor
@@ -1,0 +1,17 @@
+@using RpgRooms.Core.Domain.Entities
+<div class="rpg-section">
+  <h4>Descrição</h4>
+  @if(!IsReadOnly)
+  {
+      <textarea class="rpg-input" rows="4" @bind="Character.Background"></textarea>
+  }
+  else
+  {
+      <p>@Character.Background</p>
+  }
+</div>
+
+@code {
+  [Parameter] public Character Character { get; set; } = default!;
+  [Parameter] public bool IsReadOnly { get; set; }
+}

--- a/RpgRooms.Web/Pages/Characters/IdentificationSection.razor
+++ b/RpgRooms.Web/Pages/Characters/IdentificationSection.razor
@@ -1,0 +1,57 @@
+@using RpgRooms.Core.Domain.Entities
+<div class="rpg-section">
+  <h4>Identificação</h4>
+  <div>
+    <label>Nome:</label>
+    @if (!IsReadOnly)
+    {
+        <input class="rpg-input" @bind="Character.Name" />
+    }
+    else { <span>@Character.Name</span> }
+  </div>
+  <div>
+    <label>Raça:</label>
+    @if (!IsReadOnly)
+    {
+        <input class="rpg-input" @bind="Character.Race" />
+    }
+    else { <span>@Character.Race</span> }
+  </div>
+  <div>
+    <label>Classe:</label>
+    @if (!IsReadOnly)
+    {
+        <input class="rpg-input" @bind="Character.Class" />
+    }
+    else { <span>@Character.Class</span> }
+  </div>
+  <div>
+    <label>Nível:</label>
+    @if (!IsReadOnly)
+    {
+        <input type="number" class="rpg-input" @bind="Character.Level" />
+    }
+    else { <span>@Character.Level</span> }
+  </div>
+  <div>
+    <label>Alinhamento:</label>
+    @if (!IsReadOnly)
+    {
+        <input class="rpg-input" @bind="Character.Alignment" />
+    }
+    else { <span>@Character.Alignment</span> }
+  </div>
+  <div>
+    <label>XP:</label>
+    @if (!IsReadOnly)
+    {
+        <input type="number" class="rpg-input" @bind="Character.XP" />
+    }
+    else { <span>@Character.XP</span> }
+  </div>
+</div>
+
+@code {
+  [Parameter] public Character Character { get; set; } = default!;
+  [Parameter] public bool IsReadOnly { get; set; }
+}

--- a/RpgRooms.Web/Pages/Characters/InventorySection.razor
+++ b/RpgRooms.Web/Pages/Characters/InventorySection.razor
@@ -1,0 +1,30 @@
+@using RpgRooms.Core.Domain.Entities
+<div class="rpg-section">
+  <h4>Inventário</h4>
+  <ul>
+    @foreach(var i in Character.Inventory)
+    {
+        <li>@i.Name</li>
+    }
+  </ul>
+  @if(!IsReadOnly)
+  {
+      <input class="rpg-input" @bind="newItem" placeholder="Novo item" />
+      <button class="btn" @onclick="Add">Adicionar</button>
+  }
+</div>
+
+@code {
+  [Parameter] public Character Character { get; set; } = default!;
+  [Parameter] public bool IsReadOnly { get; set; }
+
+  string newItem = string.Empty;
+  void Add()
+  {
+      if(!string.IsNullOrWhiteSpace(newItem))
+      {
+          Character.Inventory.Add(new InventoryItem { Name = newItem });
+          newItem = string.Empty;
+      }
+  }
+}

--- a/RpgRooms.Web/Pages/Characters/SavingThrowsSection.razor
+++ b/RpgRooms.Web/Pages/Characters/SavingThrowsSection.razor
@@ -1,0 +1,55 @@
+@using RpgRooms.Core.Domain.Entities
+<div class="rpg-section">
+  <h4>Testes de Resistência</h4>
+  @foreach (var ability in abilities)
+  {
+      var proficient = Character.SavingThrowProficiencies.Any(p => p.Name == ability.Key);
+      <div>
+          @if(!IsReadOnly)
+          {
+              <input type="checkbox" checked="@proficient" @onchange="e => Toggle(ability.Key, (bool)e.Value)" />
+          }
+          <span>@ability.Display (@GetSave(ability.Key))</span>
+      </div>
+  }
+</div>
+
+@code {
+  [Parameter] public Character Character { get; set; } = default!;
+  [Parameter] public bool IsReadOnly { get; set; }
+  [Parameter] public int ProficiencyBonus { get; set; }
+
+  record Ability(string Key, string Display);
+  Ability[] abilities = new[] {
+     new Ability("Str","Força"),
+     new Ability("Dex","Destreza"),
+     new Ability("Con","Constituição"),
+     new Ability("Int","Inteligência"),
+     new Ability("Wis","Sabedoria"),
+     new Ability("Cha","Carisma")
+  };
+
+  int GetScore(string key) => key switch {
+     "Str" => Character.Str,
+     "Dex" => Character.Dex,
+     "Con" => Character.Con,
+     "Int" => Character.Int,
+     "Wis" => Character.Wis,
+     "Cha" => Character.Cha,
+     _ => 10
+  };
+  int GetMod(string key) => (GetScore(key) - 10) / 2;
+  int GetSave(string key)
+  {
+     var total = GetMod(key);
+     if (Character.SavingThrowProficiencies.Any(p => p.Name == key))
+        total += ProficiencyBonus;
+     return total;
+  }
+  void Toggle(string key, bool value)
+  {
+     var prof = Character.SavingThrowProficiencies.FirstOrDefault(p => p.Name == key);
+     if (value && prof == null) Character.SavingThrowProficiencies.Add(new SavingThrowProficiency { Name = key });
+     if (!value && prof != null) Character.SavingThrowProficiencies.Remove(prof);
+  }
+}

--- a/RpgRooms.Web/Pages/Characters/SkillsSection.razor
+++ b/RpgRooms.Web/Pages/Characters/SkillsSection.razor
@@ -1,0 +1,55 @@
+@using RpgRooms.Core.Domain.Entities
+<div class="rpg-section">
+  <h4>Perícias</h4>
+  @foreach (var skill in skills)
+  {
+      var proficient = Character.SkillProficiencies.Any(p => p.Name == skill.Name);
+      <div>
+          @if(!IsReadOnly)
+          {
+              <input type="checkbox" checked="@proficient" @onchange="e => Toggle(skill.Name, (bool)e.Value)" />
+          }
+          <span>@skill.Display (@GetTotal(skill))</span>
+      </div>
+  }
+</div>
+
+@code {
+  [Parameter] public Character Character { get; set; } = default!;
+  [Parameter] public bool IsReadOnly { get; set; }
+  [Parameter] public int ProficiencyBonus { get; set; }
+
+  record Skill(string Name, string Display, string Ability);
+  Skill[] skills = new[] {
+      new Skill("Acrobacia","Acrobacia (DEX)","Dex"),
+      new Skill("Arcanismo","Arcanismo (INT)","Int"),
+      new Skill("Atletismo","Atletismo (STR)","Str"),
+      new Skill("História","História (INT)","Int"),
+      new Skill("Furtividade","Furtividade (DEX)","Dex"),
+      new Skill("Sobrevivência","Sobrevivência (WIS)","Wis")
+  };
+
+  int GetAbilityScore(string ability) => ability switch {
+      "Str" => Character.Str,
+      "Dex" => Character.Dex,
+      "Con" => Character.Con,
+      "Int" => Character.Int,
+      "Wis" => Character.Wis,
+      "Cha" => Character.Cha,
+      _ => 10
+  };
+  int GetMod(string ability) => (GetAbilityScore(ability) - 10) / 2;
+  int GetTotal(Skill skill)
+  {
+      var total = GetMod(skill.Ability);
+      if (Character.SkillProficiencies.Any(p => p.Name == skill.Name))
+          total += ProficiencyBonus;
+      return total;
+  }
+  void Toggle(string name, bool value)
+  {
+      var prof = Character.SkillProficiencies.FirstOrDefault(p => p.Name == name);
+      if (value && prof == null) Character.SkillProficiencies.Add(new SkillProficiency { Name = name });
+      if (!value && prof != null) Character.SkillProficiencies.Remove(prof);
+  }
+}

--- a/RpgRooms.Web/Pages/_Imports.razor
+++ b/RpgRooms.Web/Pages/_Imports.razor
@@ -7,3 +7,4 @@
 @using RpgRooms.Core.Domain.Entities
 @using RpgRooms.Core.Domain.Enums
 @using RpgRooms.Core.Application.DTOs
+@using RpgRooms.Web.Pages.Characters

--- a/RpgRooms.Web/wwwroot/css/site.css
+++ b/RpgRooms.Web/wwwroot/css/site.css
@@ -6,3 +6,7 @@ body{font-family:system-ui,Segoe UI,Arial,sans-serif;margin:0}
 .btn{display:inline-block;padding:8px 12px;background:#1976d2;color:#fff;border-radius:6px;border:0;cursor:pointer}
 .chat-box{border:1px solid #ddd;height:300px;overflow:auto;padding:8px;margin:8px 0}
 .join-request-message{white-space:pre-wrap;margin:4px 0}
+.rpg-sheet{background:#fdf8e4;border:1px solid #c9b79c;padding:16px;border-radius:8px;font-family:'Book Antiqua',serif}
+.rpg-section{margin-bottom:16px;padding:8px;border:1px solid #c9b79c;background:#fff;border-radius:6px}
+.rpg-section h4{margin-top:0}
+.rpg-input{padding:4px;margin:4px 0}


### PR DESCRIPTION
## Summary
- add character sheet and edit pages
- create reusable components for identification, attributes, saving throws, skills, attacks, inventory, and description
- style character pages with RPG-inspired theme using existing CSS

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b220906bd48332b11ca1adad3ca187