### PR TITLE
feat: compute character stats dynamically

### DIFF
--- a/RpgRooms.Web/Pages/CharacterEdit.razor
+++ b/RpgRooms.Web/Pages/CharacterEdit.razor
@@ -3,11 +3,13 @@
 <div class="rpg-sheet page">
     <IdentificationSection Character="character" />
     <AttributesSection Character="character" />
-    <SavingThrowsSection Character="character" ProficiencyBonus="ProficiencyBonus" />
-    <SkillsSection Character="character" ProficiencyBonus="ProficiencyBonus" />
+    <SavingThrowsSection Character="character" />
+    <SkillsSection Character="character" />
     <AttacksSection Character="character" />
     <InventorySection Character="character" />
     <DescriptionSection Character="character" />
+    <p>Percepção Passiva: @character.GetPassivePerception()</p>
+    <p>CD de Magia: @character.GetSpellSaveDC()</p>
 </div>
 
 @code {
@@ -22,6 +24,4 @@
         Wis = 10,
         Cha = 10
     };
-
-    int ProficiencyBonus => ((character.Level - 1) / 4) + 2;
 }

--- a/RpgRooms.Web/Pages/CharacterSheet.razor
+++ b/RpgRooms.Web/Pages/CharacterSheet.razor
@@ -3,11 +3,13 @@
 <div class="rpg-sheet page">
     <IdentificationSection Character="character" IsReadOnly="true" />
     <AttributesSection Character="character" IsReadOnly="true" />
-    <SavingThrowsSection Character="character" ProficiencyBonus="ProficiencyBonus" IsReadOnly="true" />
-    <SkillsSection Character="character" ProficiencyBonus="ProficiencyBonus" IsReadOnly="true" />
+    <SavingThrowsSection Character="character" IsReadOnly="true" />
+    <SkillsSection Character="character" IsReadOnly="true" />
     <AttacksSection Character="character" IsReadOnly="true" />
     <InventorySection Character="character" IsReadOnly="true" />
     <DescriptionSection Character="character" IsReadOnly="true" />
+    <p>Percepção Passiva: @character.GetPassivePerception()</p>
+    <p>CD de Magia: @character.GetSpellSaveDC()</p>
 </div>
 
 @code {
@@ -26,6 +28,4 @@
         Wis = 13,
         Cha = 8
     };
-
-    int ProficiencyBonus => ((character.Level - 1) / 4) + 2;
 }

--- a/RpgRooms.Web/Pages/Characters/AttributesSection.razor
+++ b/RpgRooms.Web/Pages/Characters/AttributesSection.razor
@@ -8,7 +8,7 @@
         <input type="number" class="rpg-input" @bind="Character.Str" />
     }
     else { <span>@Character.Str</span> }
-    <span>Mod: @GetMod(Character.Str)</span>
+    <span>Mod: @Character.GetAbilityModifier("Str")</span>
   </div>
   <div>
     <label>Destreza:</label>
@@ -17,7 +17,7 @@
         <input type="number" class="rpg-input" @bind="Character.Dex" />
     }
     else { <span>@Character.Dex</span> }
-    <span>Mod: @GetMod(Character.Dex)</span>
+    <span>Mod: @Character.GetAbilityModifier("Dex")</span>
   </div>
   <div>
     <label>Constituição:</label>
@@ -26,7 +26,7 @@
         <input type="number" class="rpg-input" @bind="Character.Con" />
     }
     else { <span>@Character.Con</span> }
-    <span>Mod: @GetMod(Character.Con)</span>
+    <span>Mod: @Character.GetAbilityModifier("Con")</span>
   </div>
   <div>
     <label>Inteligência:</label>
@@ -35,7 +35,7 @@
         <input type="number" class="rpg-input" @bind="Character.Int" />
     }
     else { <span>@Character.Int</span> }
-    <span>Mod: @GetMod(Character.Int)</span>
+    <span>Mod: @Character.GetAbilityModifier("Int")</span>
   </div>
   <div>
     <label>Sabedoria:</label>
@@ -44,7 +44,7 @@
         <input type="number" class="rpg-input" @bind="Character.Wis" />
     }
     else { <span>@Character.Wis</span> }
-    <span>Mod: @GetMod(Character.Wis)</span>
+    <span>Mod: @Character.GetAbilityModifier("Wis")</span>
   </div>
   <div>
     <label>Carisma:</label>
@@ -53,7 +53,7 @@
         <input type="number" class="rpg-input" @bind="Character.Cha" />
     }
     else { <span>@Character.Cha</span> }
-    <span>Mod: @GetMod(Character.Cha)</span>
+    <span>Mod: @Character.GetAbilityModifier("Cha")</span>
   </div>
 </div>
 
@@ -61,5 +61,5 @@
   [Parameter] public Character Character { get; set; } = default!;
   [Parameter] public bool IsReadOnly { get; set; }
 
-  int GetMod(int score) => (score - 10) / 2;
+  
 }

--- a/RpgRooms.Web/Pages/Characters/SavingThrowsSection.razor
+++ b/RpgRooms.Web/Pages/Characters/SavingThrowsSection.razor
@@ -9,7 +9,7 @@
           {
               <input type="checkbox" checked="@proficient" @onchange="e => Toggle(ability.Key, (bool)e.Value)" />
           }
-          <span>@ability.Display (@GetSave(ability.Key))</span>
+          <span>@ability.Display (@Character.GetSavingThrow(ability.Key))</span>
       </div>
   }
 </div>
@@ -17,7 +17,6 @@
 @code {
   [Parameter] public Character Character { get; set; } = default!;
   [Parameter] public bool IsReadOnly { get; set; }
-  [Parameter] public int ProficiencyBonus { get; set; }
 
   record Ability(string Key, string Display);
   Ability[] abilities = new[] {
@@ -29,23 +28,6 @@
      new Ability("Cha","Carisma")
   };
 
-  int GetScore(string key) => key switch {
-     "Str" => Character.Str,
-     "Dex" => Character.Dex,
-     "Con" => Character.Con,
-     "Int" => Character.Int,
-     "Wis" => Character.Wis,
-     "Cha" => Character.Cha,
-     _ => 10
-  };
-  int GetMod(string key) => (GetScore(key) - 10) / 2;
-  int GetSave(string key)
-  {
-     var total = GetMod(key);
-     if (Character.SavingThrowProficiencies.Any(p => p.Name == key))
-        total += ProficiencyBonus;
-     return total;
-  }
   void Toggle(string key, bool value)
   {
      var prof = Character.SavingThrowProficiencies.FirstOrDefault(p => p.Name == key);

--- a/RpgRooms.Web/Pages/Characters/SkillsSection.razor
+++ b/RpgRooms.Web/Pages/Characters/SkillsSection.razor
@@ -9,7 +9,7 @@
           {
               <input type="checkbox" checked="@proficient" @onchange="e => Toggle(skill.Name, (bool)e.Value)" />
           }
-          <span>@skill.Display (@GetTotal(skill))</span>
+          <span>@skill.Display (@Character.GetSkillValue(skill.Name))</span>
       </div>
   }
 </div>
@@ -17,35 +17,16 @@
 @code {
   [Parameter] public Character Character { get; set; } = default!;
   [Parameter] public bool IsReadOnly { get; set; }
-  [Parameter] public int ProficiencyBonus { get; set; }
 
-  record Skill(string Name, string Display, string Ability);
+  record Skill(string Name, string Display);
   Skill[] skills = new[] {
-      new Skill("Acrobacia","Acrobacia (DEX)","Dex"),
-      new Skill("Arcanismo","Arcanismo (INT)","Int"),
-      new Skill("Atletismo","Atletismo (STR)","Str"),
-      new Skill("História","História (INT)","Int"),
-      new Skill("Furtividade","Furtividade (DEX)","Dex"),
-      new Skill("Sobrevivência","Sobrevivência (WIS)","Wis")
+      new Skill("Acrobacia","Acrobacia (DEX)"),
+      new Skill("Arcanismo","Arcanismo (INT)"),
+      new Skill("Atletismo","Atletismo (STR)"),
+      new Skill("História","História (INT)"),
+      new Skill("Furtividade","Furtividade (DEX)"),
+      new Skill("Sobrevivência","Sobrevivência (WIS)")
   };
-
-  int GetAbilityScore(string ability) => ability switch {
-      "Str" => Character.Str,
-      "Dex" => Character.Dex,
-      "Con" => Character.Con,
-      "Int" => Character.Int,
-      "Wis" => Character.Wis,
-      "Cha" => Character.Cha,
-      _ => 10
-  };
-  int GetMod(string ability) => (GetAbilityScore(ability) - 10) / 2;
-  int GetTotal(Skill skill)
-  {
-      var total = GetMod(skill.Ability);
-      if (Character.SkillProficiencies.Any(p => p.Name == skill.Name))
-          total += ProficiencyBonus;
-      return total;
-  }
   void Toggle(string name, bool value)
   {
       var prof = Character.SkillProficiencies.FirstOrDefault(p => p.Name == name);


### PR DESCRIPTION
## Summary
- centralize ability and skill calculations in `Character`
- simplify character sheet components to derive stats on the fly
- expose passive perception and spell save DC

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b221aa3eb883328e12902914b421d4