### PR TITLE
feat: manage characters on campaign exit

### DIFF
--- a/RpgRooms.Core/Application/Interfaces/ICampaignService.cs
+++ b/RpgRooms.Core/Application/Interfaces/ICampaignService.cs
@@ -17,6 +17,7 @@ public interface ICampaignService
 
     Task RemoveMemberAsync(Guid campaignId, string targetUserId, string gmUserId, string? reason = null);
     Task LeaveCampaignAsync(Guid campaignId, string userId);
+    Task HandleCharacterExitAsync(Guid campaignId, string exitedUserId, string gmUserId, string? transferToUserId);
 
     Task<IReadOnlyList<Campaign>> ListUserCampaignsAsync(string userId);
     Task<IReadOnlyList<Campaign>> ListCampaignsAsync(string? search, bool recruitingOnly, string? ownerUserId, string? status);

--- a/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
@@ -96,6 +96,13 @@ public static class CampaignEndpoints
             return Results.Ok();
         });
 
+        g.MapPut("{id:guid}/exits/{targetUserId}/characters", async (Guid id, string targetUserId, ICampaignService svc, HttpContext http, HandleExitCharactersDto dto) =>
+        {
+            var userId = http.User.Identity!.Name!;
+            await svc.HandleCharacterExitAsync(id, targetUserId, userId, dto.NewUserId);
+            return Results.Ok();
+        });
+
         g.MapGet("mine", async (ICampaignService svc, HttpContext http) =>
         {
             var userId = http.User.Identity!.Name!;
@@ -121,3 +128,4 @@ public static class CampaignEndpoints
 
 public record CreateCampaignDto(string Name, string? Description);
 public record CreateJoinRequestDto(string? Message);
+public record HandleExitCharactersDto(string? NewUserId);


### PR DESCRIPTION
## Summary
- create a default Character when a JoinRequest is approved
- allow GM to transfer or remove characters of users who exit a campaign
- add endpoint and tests for handling characters after a CampaignExit

## Testing
- `dotnet test -q` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b223b489648332a9976257459a1b41