### PR TITLE
test: adicionar testes de personagem

### DIFF
--- a/RpgRooms.Tests/CharacterEndpointsTests.cs
+++ b/RpgRooms.Tests/CharacterEndpointsTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using RpgRooms.Core.Domain.Entities;
+using RpgRooms.Infrastructure.Data;
+using RpgRooms.Infrastructure.Services;
+using Xunit;
+
+public class CharacterEndpointsTests
+{
+    private static async Task<(CharacterService svc, Character character)> CriarFichaAsync(string dbName)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase(dbName).Options;
+        var db = new AppDbContext(opts);
+        var svc = new CharacterService(db);
+        var camp = new Campaign { Name = "Camp", OwnerUserId = "gm" };
+        db.Campaigns.Add(camp);
+        await db.SaveChangesAsync();
+        var chr = new Character
+        {
+            CampaignId = camp.Id,
+            UserId = "owner",
+            Name = "Hero",
+            Str = 10,
+            Dex = 10,
+            Con = 10,
+            Int = 10,
+            Wis = 10,
+            Cha = 10
+        };
+        await svc.CreateCharacterAsync(chr);
+        return (svc, chr);
+    }
+
+    [Fact]
+    public async Task ProprietarioPodeEditar()
+    {
+        var (svc, chr) = await CriarFichaAsync("endp1");
+        var atualizado = new Character { Name = "Novo", Str = 10, Dex = 10, Con = 10, Int = 10, Wis = 10, Cha = 10 };
+        var sheet = await svc.UpdateCharacterAsync(chr.Id, atualizado, "owner");
+        Assert.Equal("Novo", sheet.Character.Name);
+    }
+
+    [Fact]
+    public async Task GmPodeEditar()
+    {
+        var (svc, chr) = await CriarFichaAsync("endp2");
+        var atualizado = new Character { Name = "GMEdit", Str = 10, Dex = 10, Con = 10, Int = 10, Wis = 10, Cha = 10 };
+        var sheet = await svc.UpdateCharacterAsync(chr.Id, atualizado, "gm");
+        Assert.Equal("GMEdit", sheet.Character.Name);
+    }
+
+    [Fact]
+    public async Task OutroUsuarioNaoPodeEditar()
+    {
+        var (svc, chr) = await CriarFichaAsync("endp3");
+        var atualizado = new Character { Name = "Hack", Str = 10, Dex = 10, Con = 10, Int = 10, Wis = 10, Cha = 10 };
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => svc.UpdateCharacterAsync(chr.Id, atualizado, "intruso"));
+    }
+}

--- a/RpgRooms.Tests/CharacterServiceTests.cs
+++ b/RpgRooms.Tests/CharacterServiceTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using RpgRooms.Core.Domain.Entities;
+using RpgRooms.Infrastructure.Data;
+using RpgRooms.Infrastructure.Services;
+using Xunit;
+
+public class CharacterServiceTests
+{
+    [Fact]
+    public async Task CalculaModificadoresSavesPericiasESpellDc()
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("charsvc1").Options;
+        var db = new AppDbContext(opts);
+        var svc = new CharacterService(db);
+        var character = new Character
+        {
+            UserId = "u1",
+            CampaignId = Guid.NewGuid(),
+            Str = 16,
+            Dex = 14,
+            Con = 12,
+            Int = 10,
+            Wis = 8,
+            Cha = 18,
+            Class = "sorcerer",
+            SavingThrowProficiencies = new List<SavingThrowProficiency>
+            {
+                new() { Name = "Dex" },
+                new() { Name = "Con" }
+            },
+            SkillProficiencies = new List<SkillProficiency>
+            {
+                new() { Name = "Acrobatics" },
+                new() { Name = "Perception" },
+                new() { Name = "Persuasion" }
+            }
+        };
+
+        var sheet = await svc.CreateCharacterAsync(character);
+
+        Assert.Equal(3, sheet.Modifiers["Str"]);
+        Assert.Equal(2, sheet.Modifiers["Dex"]);
+        Assert.Equal(1, sheet.Modifiers["Con"]);
+        Assert.Equal(0, sheet.Modifiers["Int"]);
+        Assert.Equal(-1, sheet.Modifiers["Wis"]);
+        Assert.Equal(4, sheet.Modifiers["Cha"]);
+
+        Assert.Equal(4, sheet.SavingThrows["Dex"]);
+        Assert.Equal(3, sheet.SavingThrows["Con"]);
+        Assert.Equal(-1, sheet.SavingThrows["Wis"]);
+
+        Assert.Equal(4, sheet.Skills["Acrobatics"]);
+        Assert.Equal(1, sheet.Skills["Perception"]);
+        Assert.Equal(6, sheet.Skills["Persuasion"]);
+        Assert.Equal(3, sheet.Skills["Athletics"]);
+
+        Assert.Equal(14, sheet.SpellDc);
+    }
+}


### PR DESCRIPTION
## Summary
- validar cálculos de modificadores, saves e perícias de personagem
- garantir que apenas dono ou GM atualizam fichas

## Testing
- `dotnet test` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b224c8a9f08332adf91be5bc4d54ea