### PR TITLE
Filter exit checks on join request and add SQLite tests

### DIFF
--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -95,8 +95,10 @@ public class CampaignService : ICampaignService
             throw new InvalidOperationException("Você já é membro.");
 
         var cutoff = DateTimeOffset.UtcNow.AddHours(-12);
-        var recentExit = await _db.CampaignExits
-            .AnyAsync(e => e.CampaignId == campaignId && e.UserId == userId && e.ExitedAt > cutoff);
+        var recentExit = (await _db.CampaignExits
+            .Where(e => e.CampaignId == campaignId && e.UserId == userId)
+            .ToListAsync())
+            .Any(e => e.ExitedAt > cutoff);
         if (recentExit)
             throw new InvalidOperationException("Aguarde 12h antes de solicitar novamente.");
 

--- a/RpgRooms.Tests/JoinRequestExitTests.cs
+++ b/RpgRooms.Tests/JoinRequestExitTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using RpgRooms.Infrastructure.Data;
+using RpgRooms.Infrastructure.Services;
+using Xunit;
+
+public class JoinRequestExitTests
+{
+    [Fact]
+    public async Task RejectsJoinRequestIfLeftWithin12Hours()
+    {
+        using var connection = new SqliteConnection("Filename=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using var db = new AppDbContext(options);
+        db.Database.EnsureCreated();
+        var svc = new CampaignService(db);
+        var camp = await svc.CreateCampaignAsync("gm", "A", null);
+        await svc.ToggleRecruitmentAsync(camp.Id, "gm");
+        db.CampaignMembers.Add(new() { CampaignId = camp.Id, UserId = "p1" });
+        await db.SaveChangesAsync();
+        await svc.LeaveCampaignAsync(camp.Id, "p1");
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.CreateJoinRequestAsync(camp.Id, "p1", null));
+    }
+
+    [Fact]
+    public async Task AllowsJoinRequestIfLeftMoreThan12HoursAgo()
+    {
+        using var connection = new SqliteConnection("Filename=:memory:");
+        connection.Open();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        using var db = new AppDbContext(options);
+        db.Database.EnsureCreated();
+        var svc = new CampaignService(db);
+        var camp = await svc.CreateCampaignAsync("gm", "A", null);
+        await svc.ToggleRecruitmentAsync(camp.Id, "gm");
+        db.CampaignMembers.Add(new() { CampaignId = camp.Id, UserId = "p1" });
+        await db.SaveChangesAsync();
+        await svc.LeaveCampaignAsync(camp.Id, "p1");
+        var exit = await db.CampaignExits.FirstAsync();
+        exit.ExitedAt = DateTimeOffset.UtcNow.AddHours(-13);
+        await db.SaveChangesAsync();
+        var req = await svc.CreateJoinRequestAsync(camp.Id, "p1", null);
+        Assert.NotNull(req);
+    }
+}

--- a/RpgRooms.Tests/RpgRooms.Tests.csproj
+++ b/RpgRooms.Tests/RpgRooms.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RpgRooms.Core\RpgRooms.Core.csproj" />


### PR DESCRIPTION
## Summary
- Restrict CampaignExits lookup to user and campaign, evaluating cutoff time on the client
- Add SQLite-based tests confirming join requests are only blocked within 12 hours of leaving

## Testing
- ⚠️ `dotnet test` *(dotnet CLI not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b228da8bbc8332ae229f8d9dc584dd