### PR TITLE
Use NameIdentifier claim for user identity

### DIFF
--- a/RpgRooms.Tests/CampaignChatHubTests.cs
+++ b/RpgRooms.Tests/CampaignChatHubTests.cs
@@ -76,7 +76,7 @@ class TestHubCallerClients : IHubCallerClients
 class TestHubCallerContext : HubCallerContext
 {
     public override string ConnectionId { get; }
-    public override string? UserIdentifier => User.Identity?.Name;
+    public override string? UserIdentifier => User.FindFirstValue(ClaimTypes.NameIdentifier);
     public override ClaimsPrincipal User { get; }
     private readonly Dictionary<object, object?> _items = new();
     public override IDictionary<object, object?> Items => _items;
@@ -87,6 +87,6 @@ class TestHubCallerContext : HubCallerContext
     public TestHubCallerContext(string connectionId, string userId)
     {
         ConnectionId = connectionId;
-        User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, userId) }));
+        User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, userId) }));
     }
 }

--- a/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CampaignEndpoints.cs
@@ -1,5 +1,6 @@
 using RpgRooms.Core.Application.Interfaces;
 using RpgRooms.Core.Application.DTOs;
+using System.Security.Claims;
 
 namespace RpgRooms.Web.Endpoints;
 
@@ -11,70 +12,70 @@ public static class CampaignEndpoints
 
         g.MapPost("", async (ICampaignService svc, HttpContext http, CreateCampaignDto dto) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var c = await svc.CreateCampaignAsync(userId, dto.Name, dto.Description);
             return Results.Ok(c);
         });
 
         g.MapPut("{id:guid}/recruitment/toggle", async (Guid id, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var state = await svc.ToggleRecruitmentAsync(id, userId);
             return Results.Ok(new { isRecruiting = state });
         });
 
         g.MapPut("{id:guid}/finalize", async (Guid id, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             await svc.FinalizeCampaignAsync(id, userId);
             return Results.Ok();
         });
 
         g.MapPost("{id:guid}/join-requests", async (Guid id, ICampaignService svc, HttpContext http, CreateJoinRequestDto dto) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var r = await svc.CreateJoinRequestAsync(id, userId, dto.Message);
             return Results.Ok(r);
         });
 
         g.MapPut("{id:guid}/join-requests/{reqId:guid}/approve", async (Guid id, Guid reqId, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             await svc.ApproveJoinRequestAsync(id, reqId, userId);
             return Results.Ok();
         });
 
         g.MapPut("{id:guid}/join-requests/{reqId:guid}/reject", async (Guid id, Guid reqId, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             await svc.RejectJoinRequestAsync(id, reqId, userId);
             return Results.Ok();
         });
 
         g.MapGet("{id:guid}/join-requests", async (Guid id, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var list = await svc.ListJoinRequestsAsync(id, userId);
             return Results.Ok(list);
         });
 
         g.MapGet("{id:guid}/members", async (Guid id, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var list = await svc.ListMembersAsync(id, userId);
             return Results.Ok(list);
         });
 
         g.MapGet("{id:guid}/is-member", async (Guid id, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var isMember = await svc.IsMemberAsync(id, userId);
             return Results.Ok(isMember);
         });
 
         g.MapGet("{id:guid}/messages", async (Guid id, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             if (!await svc.IsMemberAsync(id, userId) && !await svc.IsGmAsync(id, userId))
                 return Results.Forbid();
             var list = await svc.ListChatMessagesAsync(id);
@@ -84,28 +85,28 @@ public static class CampaignEndpoints
 
         g.MapDelete("{id:guid}/members/{targetUserId}", async (Guid id, string targetUserId, ICampaignService svc, HttpContext http, string? reason) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             await svc.RemoveMemberAsync(id, targetUserId, userId, reason);
             return Results.Ok();
         });
 
         g.MapDelete("{id:guid}/leave", async (Guid id, ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             await svc.LeaveCampaignAsync(id, userId);
             return Results.Ok();
         });
 
         g.MapPut("{id:guid}/exits/{targetUserId}/characters", async (Guid id, string targetUserId, ICampaignService svc, HttpContext http, HandleExitCharactersDto dto) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             await svc.HandleCharacterExitAsync(id, targetUserId, userId, dto.NewUserId);
             return Results.Ok();
         });
 
         g.MapGet("mine", async (ICampaignService svc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var list = await svc.ListUserCampaignsAsync(userId);
             return Results.Ok(list);
         });

--- a/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using RpgRooms.Core.Application.Interfaces;
 using RpgRooms.Core.Domain.Entities;
 using RpgRooms.Core.Security;
+using System.Security.Claims;
 
 namespace RpgRooms.Web.Endpoints;
 
@@ -13,7 +14,7 @@ public static class CharacterEndpoints
 
         g.MapGet("{charId:guid}", async (Guid id, Guid charId, ICharacterService charSvc, IAuthorizationService auth, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var sheet = await charSvc.GetCharacterAsync(charId);
             if (sheet is null || sheet.Character.CampaignId != id)
                 return Results.NotFound();
@@ -26,7 +27,7 @@ public static class CharacterEndpoints
 
         g.MapPost("", async (Guid id, Character character, ICharacterService charSvc, ICampaignService campSvc, IAuthorizationService auth, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var isGm = (await auth.AuthorizeAsync(http.User, null, Policies.IsGmOfCampaign)).Succeeded;
             if (!isGm && !await campSvc.IsMemberAsync(id, userId))
                 return Results.Forbid();
@@ -38,7 +39,7 @@ public static class CharacterEndpoints
 
         g.MapPut("{charId:guid}", async (Guid id, Guid charId, Character character, ICharacterService charSvc, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var sheet = await charSvc.UpdateCharacterAsync(charId, character, userId);
             if (sheet.Character.CampaignId != id)
                 return Results.BadRequest();
@@ -47,7 +48,7 @@ public static class CharacterEndpoints
 
         g.MapDelete("{charId:guid}", async (Guid id, Guid charId, ICharacterService charSvc, IAuthorizationService auth, HttpContext http) =>
         {
-            var userId = http.User.Identity!.Name!;
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var sheet = await charSvc.GetCharacterAsync(charId);
             if (sheet is null || sheet.Character.CampaignId != id)
                 return Results.NotFound();

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -8,6 +8,7 @@
 @using RpgRooms.Core.Domain.Enums
 @using System.Net
 @using Microsoft.JSInterop
+@using System.Security.Claims
 @implements IAsyncDisposable
 
 <h3>@campaign?.Name</h3>
@@ -202,7 +203,7 @@ else
         try
         {
             var c = await Http.GetFromJsonAsync<Campaign>($"/api/campaigns/{id}");
-            var me = (await AuthStateTask)!.User.Identity!.Name;
+            var me = (await AuthStateTask)!.User.FindFirstValue(ClaimTypes.NameIdentifier);
             isGm = c?.OwnerUserId == me;
         }
         catch


### PR DESCRIPTION
## Summary
- persist real user ID by using `User.FindFirstValue(ClaimTypes.NameIdentifier)` in campaign and character endpoints
- update chat hub and campaign details page to rely on user ID claim
- adjust chat hub tests for NameIdentifier claims

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b231078ca083328cea77716b990c92