### PR TITLE
Protege saída do chat quando circuito não está ativo

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -122,6 +122,9 @@ else
     bool isMember;
     bool loadFailed;
     private DotNetObjectReference<CampaignDetails>? _objRef;
+    // Indicates the component is still in the prerendering phase. Used to avoid
+    // invoking JS interop before the circuit is fully active.
+    private bool _prerendering = true;
 
     [CascadingParameter] public Task<AuthenticationState> AuthStateTask { get; set; } = default!;
 
@@ -195,6 +198,14 @@ else
         catch
         {
             loadFailed = true;
+        }
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _prerendering = false;
         }
     }
 
@@ -306,13 +317,20 @@ else
     {
         if (_objRef is not null)
         {
-            try
+            if (JS is not null && !_prerendering)
             {
-                await JS.InvokeVoidAsync("chat.leave", id.ToString());
-            }
-            catch (JSException)
-            {
-                // Ignora falhas de conexão do SignalR
+                try
+                {
+                    await JS.InvokeVoidAsync("chat.leave", id.ToString());
+                }
+                catch (JSException)
+                {
+                    // Ignora falhas de conexão do SignalR
+                }
+                catch (InvalidOperationException)
+                {
+                    // Evita invocar JS quando o circuito já foi encerrado
+                }
             }
 
             _objRef.Dispose();


### PR DESCRIPTION
## Resumo
- Adicionada flag de pré-renderização para garantir que o componente só interaja com o chat após a primeira renderização.
- Atualizado `DisposeAsync` para verificar se o circuito está ativo e capturar `InvalidOperationException` ao deixar o chat.

## Testes
- `dotnet test` *(falhou: `dotnet` não instalado)*
- `apt-get update` *(falhou: repositórios retornaram 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b23228ee18833289dfef8b4dbfde80