### PR TITLE
Show character names in campaign member list

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -81,7 +81,7 @@ else
             {
                 @foreach (var m in members)
                 {
-                    <div>@m.UserId
+                    <div>@m.UserId (@m.CharacterName)
                         <button class="btn" @onclick="() => Kick(m.UserId)" style="margin-left:4px">Remover</button>
                     </div>
                 }


### PR DESCRIPTION
## Summary
- display each member's character name alongside the user id in campaign details

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b2392067cc8332881971011f61265e