### PR TITLE
Permitir que GM defina UserId ao criar personagem

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ Base: `/api/campaigns` (auth obrigatória salvo onde indicado)
 - `DELETE /api/campaigns/{id}/members/{targetUserId}` — **GM only**; remove jogador
 - `GET /api/campaigns` — **anônimo permitido**; filtros: `search`, `recruitingOnly`, `ownerUserId`, `status`
 - `GET /api/campaigns/{id}` — **anônimo permitido**; detalhes
+- `POST /api/campaigns/{id}/characters` — cria personagem
+  - **GM** pode definir `userId` no corpo para criar para outro jogador
+  - jogadores comuns sempre usarão o próprio `userId` independentemente do enviado
 
 ### Exemplo (PowerShell + `curl`)
 ```powershell

--- a/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
@@ -31,7 +31,10 @@ public static class CharacterEndpoints
             var isGm = (await auth.AuthorizeAsync(http.User, null, Policies.IsGmOfCampaign)).Succeeded;
             if (!isGm && !await campSvc.IsMemberAsync(id, userId))
                 return Results.Forbid();
-            character.UserId = userId;
+
+            // Only GMs may create characters for other users. For regular players,
+            // the UserId is always set to the caller to prevent impersonation.
+            character.UserId = isGm ? character.UserId : userId;
             character.CampaignId = id;
             var sheet = await charSvc.CreateCharacterAsync(character);
             return Results.Ok(sheet);


### PR DESCRIPTION
## Summary
- allow GMs to create characters for any user
- document character creation endpoint and GM behaviour

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b23af78b9083328444da9f32665045