### PR TITLE
Implement character listing endpoint and UI links

### DIFF
--- a/RpgRooms.Core/Application/Interfaces/ICharacterService.cs
+++ b/RpgRooms.Core/Application/Interfaces/ICharacterService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 using RpgRooms.Core.Application.DTOs;
 using RpgRooms.Core.Domain.Entities;
@@ -10,5 +11,6 @@ public interface ICharacterService
     Task<CharacterSheetDto> CreateCharacterAsync(Character character);
     Task<CharacterSheetDto> UpdateCharacterAsync(Guid id, Character character, string userId);
     Task<CharacterSheetDto?> GetCharacterAsync(Guid id);
+    Task<IEnumerable<CharacterSheetDto>> GetCharactersAsync(Guid campaignId, string userId);
     Task DeleteCharacterAsync(Guid id, string userId);
 }

--- a/RpgRooms.Infrastructure/Services/CharacterService.cs
+++ b/RpgRooms.Infrastructure/Services/CharacterService.cs
@@ -80,6 +80,16 @@ public class CharacterService : ICharacterService
         return c is null ? null : BuildSheet(c);
     }
 
+    public async Task<IEnumerable<CharacterSheetDto>> GetCharactersAsync(Guid campaignId, string userId)
+    {
+        var chars = await _db.Characters
+            .Include(c => c.SavingThrowProficiencies)
+            .Include(c => c.SkillProficiencies)
+            .Where(c => c.CampaignId == campaignId && c.UserId == userId)
+            .ToListAsync();
+        return chars.Select(BuildSheet);
+    }
+
     public async Task DeleteCharacterAsync(Guid id, string userId)
     {
         var existing = await _db.Characters

--- a/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
@@ -12,6 +12,15 @@ public static class CharacterEndpoints
     {
         var g = app.MapGroup("/api/campaigns/{id:guid}/characters").RequireAuthorization();
 
+        g.MapGet("", async (Guid id, ICharacterService charSvc, ICampaignService campSvc, HttpContext http) =>
+        {
+            var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+            if (!await campSvc.IsMemberAsync(id, userId) && !await campSvc.IsGmAsync(id, userId))
+                return Results.Forbid();
+            var list = await charSvc.GetCharactersAsync(id, userId);
+            return Results.Ok(list);
+        });
+
         g.MapGet("{charId:guid}", async (Guid id, Guid charId, ICharacterService charSvc, IAuthorizationService auth, HttpContext http) =>
         {
             var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -88,6 +88,19 @@ else
             }
         }
 
+        <h4>Meus Personagens</h4>
+        @if (characters.Count == 0)
+        {
+            <p>Nenhum personagem.</p>
+        }
+        else
+        {
+            @foreach (var c in characters)
+            {
+                <div><a href="/campaigns/@id/characters/@c.Character.Id/edit">@c.Character.Name</a></div>
+            }
+        }
+
         <hr />
         <h4>Chat</h4>
         <label>Nome para exibir</label>
@@ -113,6 +126,7 @@ else
     List<ChatMessageDto> messages = new();
     List<JoinRequest> joinRequests = new();
     List<CampaignMember> members = new();
+    List<CharacterSheetDto> characters = new();
     string message = string.Empty;
     string displayName = string.Empty;
     string joinMessage = string.Empty;
@@ -157,6 +171,15 @@ else
                 if (messagesResponse.IsSuccessStatusCode)
                 {
                     messages = await messagesResponse.Content.ReadFromJsonAsync<List<ChatMessageDto>>() ?? new();
+                }
+
+                try
+                {
+                    characters = await Http.GetFromJsonAsync<List<CharacterSheetDto>>($"/api/campaigns/{id}/characters") ?? new();
+                }
+                catch
+                {
+                    characters = new();
                 }
 
                 if (isGm)

--- a/RpgRooms.Web/Pages/CharacterSheet.razor
+++ b/RpgRooms.Web/Pages/CharacterSheet.razor
@@ -1,31 +1,57 @@
-@page "/characters/sheet"
+@page "/campaigns/{campaignId:guid}/characters/{characterId}"
+@attribute [Authorize]
+@inject HttpClient Http
+
 <h3>Ficha de Personagem</h3>
-<div class="rpg-sheet page">
-    <IdentificationSection Character="character" IsReadOnly="true" />
-    <AttributesSection Character="character" IsReadOnly="true" />
-    <SavingThrowsSection Character="character" IsReadOnly="true" />
-    <SkillsSection Character="character" IsReadOnly="true" />
-    <AttacksSection Character="character" IsReadOnly="true" />
-    <InventorySection Character="character" IsReadOnly="true" />
-    <DescriptionSection Character="character" IsReadOnly="true" />
-    <p>Percepção Passiva: @character.GetPassivePerception()</p>
-    <p>CD de Magia: @character.GetSpellSaveDC()</p>
-</div>
+
+@if (!loaded)
+{
+    <p>Carregando...</p>
+}
+else if (!string.IsNullOrEmpty(error))
+{
+    <p class="text-danger">@error</p>
+}
+else
+{
+    <div class="rpg-sheet page">
+        <IdentificationSection Character="character" IsReadOnly="true" />
+        <AttributesSection Character="character" IsReadOnly="true" />
+        <SavingThrowsSection Character="character" IsReadOnly="true" />
+        <SkillsSection Character="character" IsReadOnly="true" />
+        <AttacksSection Character="character" IsReadOnly="true" />
+        <InventorySection Character="character" IsReadOnly="true" />
+        <DescriptionSection Character="character" IsReadOnly="true" />
+        <p>Percepção Passiva: @character.GetPassivePerception()</p>
+        <p>CD de Magia: @character.GetSpellSaveDC()</p>
+    </div>
+}
 
 @code {
-    Character character = new()
+    [Parameter] public Guid campaignId { get; set; }
+    [Parameter] public Guid characterId { get; set; }
+
+    Character character = new();
+    bool loaded;
+    string? error;
+
+    protected override async Task OnInitializedAsync()
     {
-        Name = "Herói",
-        Race = "Humano",
-        Class = "Guerreiro",
-        Level = 1,
-        Alignment = "ND",
-        Background = "Um guerreiro corajoso.",
-        Str = 15,
-        Dex = 12,
-        Con = 14,
-        Int = 10,
-        Wis = 13,
-        Cha = 8
-    };
+        try
+        {
+            var sheet = await Http.GetFromJsonAsync<CharacterSheetDto>(
+                $"/api/campaigns/{campaignId}/characters/{characterId}");
+            if (sheet?.Character is not null)
+                character = sheet.Character;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            loaded = true;
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
- add `GET /api/campaigns/{id}/characters` to return current user's character sheets
- list and link user characters in campaign details
- load character sheet data via HTTP instead of hardcoded values

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e8793548332923b1e3726047c3a