### PR TITLE
Redirect new members to character creation screen

### DIFF
--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -120,25 +120,6 @@ public class CampaignService : ICampaignService
         req.Status = JoinRequestStatus.Approved;
         req.DecisionAt = DateTimeOffset.UtcNow;
         _db.CampaignMembers.Add(new CampaignMember { CampaignId = campaignId, UserId = req.UserId });
-        var character = new Character
-        {
-            CampaignId = campaignId,
-            UserId = req.UserId,
-            Name = "New Character",
-            Level = 1,
-            Str = 10,
-            Dex = 10,
-            Con = 10,
-            Int = 10,
-            Wis = 10,
-            Cha = 10
-        };
-        _db.Characters.Add(character);
-        await _db.SaveChangesAsync();
-
-        var member = await _db.CampaignMembers
-            .FirstAsync(m => m.CampaignId == campaignId && m.UserId == req.UserId);
-        member.CharacterName = character.Name;
         await _db.SaveChangesAsync();
         await Audit("ApproveJoin", gmUserId, campaignId, new { req.UserId });
 

--- a/RpgRooms.Tests/CampaignRulesTests.cs
+++ b/RpgRooms.Tests/CampaignRulesTests.cs
@@ -128,7 +128,7 @@ public class CampaignRulesTests
     }
 
     [Fact]
-    public async Task AprovarJoinCriaCharacter()
+    public async Task AprovarJoinNaoCriaCharacter()
     {
         var opts = new DbContextOptionsBuilder<AppDbContext>().UseInMemoryDatabase("t9").Options;
         var db = new AppDbContext(opts);
@@ -137,7 +137,7 @@ public class CampaignRulesTests
         await svc.ToggleRecruitmentAsync(camp.Id, "gm");
         var req = await svc.CreateJoinRequestAsync(camp.Id, "p1", null);
         await svc.ApproveJoinRequestAsync(camp.Id, req.Id, "gm");
-        Assert.Equal(1, await db.Characters.CountAsync());
+        Assert.Equal(0, await db.Characters.CountAsync());
     }
 
     [Fact]
@@ -150,6 +150,8 @@ public class CampaignRulesTests
         await svc.ToggleRecruitmentAsync(camp.Id, "gm");
         var req = await svc.CreateJoinRequestAsync(camp.Id, "p1", null);
         await svc.ApproveJoinRequestAsync(camp.Id, req.Id, "gm");
+        var charSvc = new CharacterService(db);
+        await charSvc.CreateCharacterAsync(new Character { CampaignId = camp.Id, UserId = "p1", Name = "Hero" });
         await svc.LeaveCampaignAsync(camp.Id, "p1");
         await svc.HandleCharacterExitAsync(camp.Id, "p1", "gm", null);
         Assert.Equal(0, await db.Characters.CountAsync());
@@ -167,10 +169,11 @@ public class CampaignRulesTests
         await svc.ApproveJoinRequestAsync(camp.Id, req1.Id, "gm");
         var req2 = await svc.CreateJoinRequestAsync(camp.Id, "p2", null);
         await svc.ApproveJoinRequestAsync(camp.Id, req2.Id, "gm");
+        var charSvc = new CharacterService(db);
+        var sheet = await charSvc.CreateCharacterAsync(new Character { CampaignId = camp.Id, UserId = "p1", Name = "Hero" });
         await svc.LeaveCampaignAsync(camp.Id, "p1");
-        var character = await db.Characters.FirstAsync(c => c.UserId == "p1");
         await svc.HandleCharacterExitAsync(camp.Id, "p1", "gm", "p2");
-        var updated = await db.Characters.FirstAsync(c => c.Id == character.Id);
+        var updated = await db.Characters.FirstAsync(c => c.Id == sheet.Character.Id);
         Assert.Equal("p2", updated.UserId);
     }
 

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -185,6 +185,17 @@ else
                     characters = new();
                 }
 
+                if (isMember && !isGm && characters.Count == 0)
+                {
+                    var res = await Http.PostAsJsonAsync($"/api/campaigns/{id}/characters", new Character());
+                    if (res.IsSuccessStatusCode)
+                    {
+                        var sheet = await res.Content.ReadFromJsonAsync<CharacterSheetDto>();
+                        Nav.NavigateTo($"/campaigns/{id}/characters/{sheet!.Character.Id}/edit", true);
+                        return;
+                    }
+                }
+
                 if (isGm)
                 {
                     try


### PR DESCRIPTION
## Summary
- stop creating a default "New Character" when approving join requests
- redirect newly approved players without characters to the CharacterEdit page to save their sheet
- update campaign tests for new character workflow

## Testing
- ⚠️ `dotnet test` *(failed: command not found)*
- ⚠️ `apt-get update` *(failed: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b241e620c883329a50d1ee1db8c112