### PR TITLE
Initialize member character IDs during member load

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -268,6 +268,10 @@ else
     private async Task LoadMembers()
     {
         members = await Http.GetFromJsonAsync<List<CampaignMember>>($"/api/campaigns/{id}/members") ?? new();
+        foreach (var member in members)
+        {
+            memberCharIds.TryAdd(member.UserId, string.Empty);
+        }
     }
 
     [JSInvokable]


### PR DESCRIPTION
## Summary
- ensure memberCharIds dictionary has entries for each campaign member

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fa70c1d88332abe3c7d1bdf35a3d