### PR TITLE
Expand skill list and test proficiency handling

### DIFF
--- a/RpgRooms.Tests/CharacterSkillValueTests.cs
+++ b/RpgRooms.Tests/CharacterSkillValueTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using RpgRooms.Core.Domain.Entities;
+using Xunit;
+
+public class CharacterSkillValueTests
+{
+    public static IEnumerable<object[]> AllSkills => new[]
+    {
+        new object[] { "Acrobatics" },
+        new object[] { "Animal Handling" },
+        new object[] { "Arcana" },
+        new object[] { "Athletics" },
+        new object[] { "Deception" },
+        new object[] { "History" },
+        new object[] { "Insight" },
+        new object[] { "Intimidation" },
+        new object[] { "Investigation" },
+        new object[] { "Medicine" },
+        new object[] { "Nature" },
+        new object[] { "Perception" },
+        new object[] { "Performance" },
+        new object[] { "Persuasion" },
+        new object[] { "Religion" },
+        new object[] { "Sleight of Hand" },
+        new object[] { "Stealth" },
+        new object[] { "Survival" },
+    };
+
+    [Theory]
+    [MemberData(nameof(AllSkills))]
+    public void ProficiencyAffectsSkillValue(string skill)
+    {
+        var character = new Character
+        {
+            Level = 1,
+            Str = 10,
+            Dex = 10,
+            Con = 10,
+            Int = 10,
+            Wis = 10,
+            Cha = 10,
+            SkillProficiencies = new List<SkillProficiency>()
+        };
+
+        Assert.Equal(0, character.GetSkillValue(skill));
+
+        character.SkillProficiencies.Add(new SkillProficiency { Name = skill });
+
+        Assert.Equal(2, character.GetSkillValue(skill));
+    }
+}
+

--- a/RpgRooms.Web/Pages/Characters/SkillsSection.razor
+++ b/RpgRooms.Web/Pages/Characters/SkillsSection.razor
@@ -20,12 +20,24 @@
 
   record Skill(string Name, string Display);
   Skill[] skills = new[] {
-      new Skill("Acrobacia","Acrobacia (DEX)"),
-      new Skill("Arcanismo","Arcanismo (INT)"),
-      new Skill("Atletismo","Atletismo (STR)"),
-      new Skill("História","História (INT)"),
-      new Skill("Furtividade","Furtividade (DEX)"),
-      new Skill("Sobrevivência","Sobrevivência (WIS)")
+      new Skill("Acrobatics","Acrobatics (DEX)"),
+      new Skill("Animal Handling","Animal Handling (WIS)"),
+      new Skill("Arcana","Arcana (INT)"),
+      new Skill("Athletics","Athletics (STR)"),
+      new Skill("Deception","Deception (CHA)"),
+      new Skill("History","History (INT)"),
+      new Skill("Insight","Insight (WIS)"),
+      new Skill("Intimidation","Intimidation (CHA)"),
+      new Skill("Investigation","Investigation (INT)"),
+      new Skill("Medicine","Medicine (WIS)"),
+      new Skill("Nature","Nature (INT)"),
+      new Skill("Perception","Perception (WIS)"),
+      new Skill("Performance","Performance (CHA)"),
+      new Skill("Persuasion","Persuasion (CHA)"),
+      new Skill("Religion","Religion (INT)"),
+      new Skill("Sleight of Hand","Sleight of Hand (DEX)"),
+      new Skill("Stealth","Stealth (DEX)"),
+      new Skill("Survival","Survival (WIS)")
   };
   void Toggle(string name, bool value)
   {


### PR DESCRIPTION
## Summary
- add remaining D&D skills to `SkillsSection` with correct ability tags
- cover all skills in unit tests to ensure proficiency bonus is applied

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b30885dcbc8332b2a830022304d6ff