### PR TITLE
Allow GMs to list all campaign characters

### DIFF
--- a/RpgRooms.Core/Application/Interfaces/ICharacterService.cs
+++ b/RpgRooms.Core/Application/Interfaces/ICharacterService.cs
@@ -11,6 +11,6 @@ public interface ICharacterService
     Task<CharacterSheetDto> CreateCharacterAsync(Character character);
     Task<CharacterSheetDto> UpdateCharacterAsync(Guid id, Character character, string userId);
     Task<CharacterSheetDto?> GetCharacterAsync(Guid id);
-    Task<IEnumerable<CharacterSheetDto>> GetCharactersAsync(Guid campaignId, string userId);
+    Task<IEnumerable<CharacterSheetDto>> GetCharactersAsync(Guid campaignId, string userId, bool isGm);
     Task DeleteCharacterAsync(Guid id, string userId);
 }

--- a/RpgRooms.Infrastructure/Services/CharacterService.cs
+++ b/RpgRooms.Infrastructure/Services/CharacterService.cs
@@ -82,13 +82,17 @@ public class CharacterService : ICharacterService
         return c is null ? null : BuildSheet(c);
     }
 
-    public async Task<IEnumerable<CharacterSheetDto>> GetCharactersAsync(Guid campaignId, string userId)
+    public async Task<IEnumerable<CharacterSheetDto>> GetCharactersAsync(Guid campaignId, string userId, bool isGm)
     {
-        var chars = await _db.Characters
+        var query = _db.Characters
             .Include(c => c.SavingThrowProficiencies)
             .Include(c => c.SkillProficiencies)
-            .Where(c => c.CampaignId == campaignId && c.UserId == userId)
-            .ToListAsync();
+            .Where(c => c.CampaignId == campaignId);
+
+        if (!isGm)
+            query = query.Where(c => c.UserId == userId);
+
+        var chars = await query.ToListAsync();
         return chars.Select(BuildSheet);
     }
 

--- a/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
+++ b/RpgRooms.Web/Endpoints/CharacterEndpoints.cs
@@ -15,9 +15,10 @@ public static class CharacterEndpoints
         g.MapGet("", async (Guid id, ICharacterService charSvc, ICampaignService campSvc, HttpContext http) =>
         {
             var userId = http.User.FindFirstValue(ClaimTypes.NameIdentifier)!;
-            if (!await campSvc.IsMemberAsync(id, userId) && !await campSvc.IsGmAsync(id, userId))
+            var isGm = await campSvc.IsGmAsync(id, userId);
+            if (!isGm && !await campSvc.IsMemberAsync(id, userId))
                 return Results.Forbid();
-            var list = await charSvc.GetCharactersAsync(id, userId);
+            var list = await charSvc.GetCharactersAsync(id, userId, isGm);
             return Results.Ok(list);
         });
 

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -90,7 +90,7 @@ else
             }
         }
 
-        <h4>Meus Personagens</h4>
+        <h4>@(isGm ? "Personagens" : "Meus Personagens")</h4>
         @if (characters.Count == 0)
         {
             <p>Nenhum personagem.</p>
@@ -99,7 +99,17 @@ else
         {
             @foreach (var c in characters)
             {
-                <div><a href="/campaigns/@id/characters/@c.Character.Id/edit">@c.Character.Name</a></div>
+                if (isGm)
+                {
+                    <div>
+                        <a href="/campaigns/@id/characters/@c.Character.Id">@c.Character.Name</a>
+                        <a href="/campaigns/@id/characters/@c.Character.Id/edit" style="margin-left:4px">Editar</a>
+                    </div>
+                }
+                else
+                {
+                    <div><a href="/campaigns/@id/characters/@c.Character.Id/edit">@c.Character.Name</a></div>
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Extend character listing to accept GM flag and return all campaign characters for GMs
- Pass GM status from endpoint and expose full character list in campaign details

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b309bf3d9083329abc580e4fdd2662