### PR TITLE
handle JS disconnect when leaving chat

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -383,6 +383,10 @@ else
                 {
                     await JS.InvokeVoidAsync("chat.leave", id.ToString());
                 }
+                catch (JSDisconnectedException)
+                {
+                    // Ignora chamadas quando o circuito foi desconectado
+                }
                 catch (JSException)
                 {
                     // Ignora falhas de conexão do SignalR


### PR DESCRIPTION
## Summary
- handle JS disconnection gracefully when leaving campaign chat by catching `JSDisconnectedException`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b30dea2ed883328fd140f9466f13cf