### PR TITLE
Improve character creation and linking

### DIFF
--- a/RpgRooms.Core/Domain/Entities/CampaignMember.cs
+++ b/RpgRooms.Core/Domain/Entities/CampaignMember.cs
@@ -5,6 +5,7 @@ public class CampaignMember
     public Guid Id { get; set; } = Guid.NewGuid();
     public Guid CampaignId { get; set; }
     public string UserId { get; set; } = string.Empty;
+    public Guid? CharacterId { get; set; }
     public string? CharacterName { get; set; }
     public DateTimeOffset JoinedAt { get; set; } = DateTimeOffset.UtcNow;
     public bool IsBanned { get; set; } = false;

--- a/RpgRooms.Infrastructure/Data/AppDbContext.cs
+++ b/RpgRooms.Infrastructure/Data/AppDbContext.cs
@@ -32,6 +32,10 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
     {
         base.OnModelCreating(b);
         b.Entity<CampaignMember>().HasIndex(m => new { m.CampaignId, m.UserId }).IsUnique();
+        b.Entity<CampaignMember>()
+            .HasOne<Character>()
+            .WithMany()
+            .HasForeignKey(m => m.CharacterId);
         b.Entity<Campaign>()
             .HasIndex(c => new { c.OwnerUserId, c.Name })
             .IsUnique();

--- a/RpgRooms.Infrastructure/Migrations/20241215000000_AddMemberCharacterLink.cs
+++ b/RpgRooms.Infrastructure/Migrations/20241215000000_AddMemberCharacterLink.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations;
+
+public partial class AddMemberCharacterLink : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<Guid>(
+            name: "CharacterId",
+            table: "CampaignMembers",
+            type: "TEXT",
+            nullable: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_CampaignMembers_CharacterId",
+            table: "CampaignMembers",
+            column: "CharacterId");
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_CampaignMembers_Characters_CharacterId",
+            table: "CampaignMembers",
+            column: "CharacterId",
+            principalTable: "Characters",
+            principalColumn: "Id");
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_CampaignMembers_Characters_CharacterId",
+            table: "CampaignMembers");
+
+        migrationBuilder.DropIndex(
+            name: "IX_CampaignMembers_CharacterId",
+            table: "CampaignMembers");
+
+        migrationBuilder.DropColumn(
+            name: "CharacterId",
+            table: "CampaignMembers");
+    }
+}

--- a/RpgRooms.Infrastructure/Services/CampaignService.cs
+++ b/RpgRooms.Infrastructure/Services/CampaignService.cs
@@ -264,6 +264,7 @@ public class CampaignService : ICampaignService
         var member = await _db.CampaignMembers.FirstOrDefaultAsync(m => m.CampaignId == campaignId && m.UserId == targetUserId)
             ?? throw new InvalidOperationException("Membro não encontrado");
 
+        member.CharacterId = characterId;
         member.CharacterName = character.Name;
         await _db.SaveChangesAsync();
         await Audit("SetMemberCharacter", gmUserId, campaignId, new { targetUserId, characterId });

--- a/RpgRooms.Tests/CampaignRulesTests.cs
+++ b/RpgRooms.Tests/CampaignRulesTests.cs
@@ -203,5 +203,6 @@ public class CampaignRulesTests
         await svc.SetMemberCharacterAsync(camp.Id, "p1", ch.Id, "gm");
         var member = await db.CampaignMembers.FirstAsync(m => m.CampaignId == camp.Id && m.UserId == "p1");
         Assert.Equal("Hero", member.CharacterName);
+        Assert.Equal(ch.Id, member.CharacterId);
     }
 }

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -113,6 +113,11 @@ else
             }
         }
 
+        @if (isMember && !isGm)
+        {
+            <button class="btn" @onclick="CreateCharacter">Criar Ficha</button>
+        }
+
         <hr />
         <h4>Chat</h4>
         <label>Nome para exibir</label>
@@ -193,17 +198,6 @@ else
                 catch
                 {
                     characters = new();
-                }
-
-                if (isMember && !isGm && characters.Count == 0)
-                {
-                    var res = await Http.PostAsJsonAsync($"/api/campaigns/{id}/characters", new Character());
-                    if (res.IsSuccessStatusCode)
-                    {
-                        var sheet = await res.Content.ReadFromJsonAsync<CharacterSheetDto>();
-                        Nav.NavigateTo($"/campaigns/{id}/characters/{sheet!.Character.Id}/edit", true);
-                        return;
-                    }
                 }
 
                 if (isGm)
@@ -343,6 +337,19 @@ else
         var res = await Http.DeleteAsync($"/api/campaigns/{id}/members/{userId}");
         res.EnsureSuccessStatusCode();
         await LoadMembers();
+    }
+
+    private async Task CreateCharacter()
+    {
+        var name = await JS.InvokeAsync<string?>("prompt", "Nome do personagem:");
+        if (string.IsNullOrWhiteSpace(name) || name.Length < 3) return;
+        var res = await Http.PostAsJsonAsync($"/api/campaigns/{id}/characters", new Character { Name = name });
+        if (res.IsSuccessStatusCode)
+        {
+            var sheet = await res.Content.ReadFromJsonAsync<CharacterSheetDto>();
+            if (sheet?.Character is not null)
+                Nav.NavigateTo($"/campaigns/{id}/characters/{sheet.Character.Id}/edit", true);
+        }
     }
 
     private async Task SetCharacter(string userId)


### PR DESCRIPTION
## Summary
- add CharacterId to campaign members and map to characters
- replace automatic sheet creation with explicit "Criar Ficha" flow
- persist member-character link and update tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31725678c83328739e002514a530e