### PR TITLE
feat: navigate to campaign after character save

### DIFF
--- a/RpgRooms.Web/Pages/CharacterEdit.razor
+++ b/RpgRooms.Web/Pages/CharacterEdit.razor
@@ -1,6 +1,7 @@
 @page "/campaigns/{campaignId:guid}/characters/{characterId:guid}/edit"
 @attribute [Authorize]
 @inject HttpClient Http
+@inject NavigationManager Nav
 
 <h3>Editar Personagem</h3>
 
@@ -66,6 +67,9 @@ else
     {
         var res = await Http.PutAsJsonAsync(
             $"/api/campaigns/{campaignId}/characters/{characterId}", character);
-        res.EnsureSuccessStatusCode();
+        if (res.IsSuccessStatusCode)
+        {
+            Nav.NavigateTo($"/campaigns/{campaignId}");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- inject `NavigationManager` into character edit page
- redirect to campaign after successfully saving a character

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b325545bc08332998c772830f92bfb