### PR TITLE
fix: avoid concurrency exception when updating character collections

### DIFF
--- a/RpgRooms.Infrastructure/Services/CharacterService.cs
+++ b/RpgRooms.Infrastructure/Services/CharacterService.cs
@@ -75,10 +75,6 @@ public class CharacterService : ICharacterService
         _db.SkillProficiencies.RemoveRange(existing.SkillProficiencies);
         _db.Languages.RemoveRange(existing.Languages);
         _db.Features.RemoveRange(existing.Features);
-        existing.SavingThrowProficiencies.Clear();
-        existing.SkillProficiencies.Clear();
-        existing.Languages.Clear();
-        existing.Features.Clear();
 
         foreach (var p in character.SavingThrowProficiencies)
             existing.SavingThrowProficiencies.Add(


### PR DESCRIPTION
## Summary
- remove redundant `Clear()` calls after `RemoveRange()` in `UpdateCharacterAsync`

## Testing
- `dotnet test --filter "AtualizaColecoesRemoveRegistrosAntigos"` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68b3282446e48332978fac24aac9d63e