### PR TITLE
Fix collection update for characters

### DIFF
--- a/RpgRooms.Infrastructure/Services/CharacterService.cs
+++ b/RpgRooms.Infrastructure/Services/CharacterService.cs
@@ -76,6 +76,13 @@ public class CharacterService : ICharacterService
         _db.Languages.RemoveRange(existing.Languages);
         _db.Features.RemoveRange(existing.Features);
 
+        existing.SavingThrowProficiencies.Clear();
+        existing.SkillProficiencies.Clear();
+        existing.Languages.Clear();
+        existing.Features.Clear();
+
+        await _db.SaveChangesAsync();
+
         foreach (var p in character.SavingThrowProficiencies)
             existing.SavingThrowProficiencies.Add(
                 new SavingThrowProficiency { CharacterId = existing.Id, Name = p.Name }


### PR DESCRIPTION
## Summary
- clear character navigation collections before re-adding and persist removal changes

## Testing
- `dotnet test --filter CharacterServiceTests.AtualizaColecoesRemoveRegistrosAntigos` *(fails: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b32ae98cc48332b371009cfcbce9d5