### PR TITLE
Avoid extra save when updating character collections

### DIFF
--- a/RpgRooms.Infrastructure/Services/CharacterService.cs
+++ b/RpgRooms.Infrastructure/Services/CharacterService.cs
@@ -81,8 +81,6 @@ public class CharacterService : ICharacterService
         existing.Languages.Clear();
         existing.Features.Clear();
 
-        await _db.SaveChangesAsync();
-
         foreach (var p in character.SavingThrowProficiencies)
             existing.SavingThrowProficiencies.Add(
                 new SavingThrowProficiency { CharacterId = existing.Id, Name = p.Name }


### PR DESCRIPTION
## Summary
- Remove intermediate SaveChangesAsync in UpdateCharacterAsync
- Update character collections and save once at the end

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b34b8740cc833281ea0b108fb4f28c