### PR TITLE
Fix character save navigation and concurrency

### DIFF
--- a/RpgRooms.Infrastructure/Services/CharacterService.cs
+++ b/RpgRooms.Infrastructure/Services/CharacterService.cs
@@ -71,10 +71,14 @@ public class CharacterService : ICharacterService
         existing.DeathSaves = character.DeathSaves;
         existing.Inspiration = character.Inspiration;
 
-        _db.SavingThrowProficiencies.RemoveRange(existing.SavingThrowProficiencies);
-        _db.SkillProficiencies.RemoveRange(existing.SkillProficiencies);
-        _db.Languages.RemoveRange(existing.Languages);
-        _db.Features.RemoveRange(existing.Features);
+        // Remove existing aggregates first to avoid concurrency issues when
+        // replacing the related collections. Copying the collections to lists
+        // prevents modification during enumeration.
+        _db.SavingThrowProficiencies.RemoveRange(existing.SavingThrowProficiencies.ToList());
+        _db.SkillProficiencies.RemoveRange(existing.SkillProficiencies.ToList());
+        _db.Languages.RemoveRange(existing.Languages.ToList());
+        _db.Features.RemoveRange(existing.Features.ToList());
+        await _db.SaveChangesAsync();
 
         existing.SavingThrowProficiencies.Clear();
         existing.SkillProficiencies.Clear();

--- a/RpgRooms.Web/Pages/CharacterEdit.razor
+++ b/RpgRooms.Web/Pages/CharacterEdit.razor
@@ -1,6 +1,7 @@
 @page "/campaigns/{campaignId:guid}/characters/{characterId:guid}/edit"
 @attribute [Authorize]
 @inject HttpClient Http
+@inject NavigationManager Nav
 
 <h3>Editar Personagem</h3>
 
@@ -64,8 +65,23 @@ else
 
     private async Task Save()
     {
-        var res = await Http.PutAsJsonAsync(
-            $"/api/campaigns/{campaignId}/characters/{characterId}", character);
-        res.EnsureSuccessStatusCode();
+        error = null;
+        try
+        {
+            var res = await Http.PutAsJsonAsync(
+                $"/api/campaigns/{campaignId}/characters/{characterId}", character);
+            if (res.IsSuccessStatusCode)
+            {
+                Nav.NavigateTo($"/campaigns/{campaignId}");
+            }
+            else
+            {
+                error = $"Falha ao salvar ficha ({res.StatusCode})";
+            }
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure character sheet save removes old proficiencies before re-adding to avoid concurrency
- redirect back to campaign after successfully saving a character

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34f2369448332914de97b0f212924