### PR TITLE
Add skill roll chat messages

### DIFF
--- a/RpgRooms.Web/Pages/CharacterEdit.razor
+++ b/RpgRooms.Web/Pages/CharacterEdit.razor
@@ -19,7 +19,7 @@ else
         <IdentificationSection Character="character" IsReadOnly="IsReadOnly" />
         <AttributesSection Character="character" IsReadOnly="IsReadOnly" />
         <SavingThrowsSection Character="character" IsReadOnly="IsReadOnly" />
-        <SkillsSection Character="character" IsReadOnly="IsReadOnly" />
+        <SkillsSection Character="character" IsReadOnly="IsReadOnly" CampaignId="campaignId" />
         <CombatSection Character="character" IsReadOnly="IsReadOnly" />
         <LanguagesSection Character="character" IsReadOnly="IsReadOnly" />
         <FeaturesSection Character="character" IsReadOnly="IsReadOnly" />

--- a/RpgRooms.Web/Pages/CharacterSheet.razor
+++ b/RpgRooms.Web/Pages/CharacterSheet.razor
@@ -18,7 +18,7 @@ else
         <IdentificationSection Character="character" IsReadOnly="true" />
         <AttributesSection Character="character" IsReadOnly="true" />
         <SavingThrowsSection Character="character" IsReadOnly="true" />
-        <SkillsSection Character="character" IsReadOnly="true" />
+        <SkillsSection Character="character" IsReadOnly="true" CampaignId="campaignId" />
         <CombatSection Character="character" IsReadOnly="true" />
         <LanguagesSection Character="character" IsReadOnly="true" />
         <FeaturesSection Character="character" IsReadOnly="true" />

--- a/RpgRooms.Web/Pages/Characters/SkillsSection.razor
+++ b/RpgRooms.Web/Pages/Characters/SkillsSection.razor
@@ -1,4 +1,5 @@
 @using RpgRooms.Core.Domain.Entities
+@inject IJSRuntime JS
 <div class="rpg-section">
   <h4>Perícias</h4>
   @foreach (var skill in skills)
@@ -10,6 +11,7 @@
               <input type="checkbox" checked="@proficient" @onchange="e => Toggle(skill.Name, (bool)e.Value)" />
           }
           <span>@skill.Display (@Character.GetSkillValue(skill.Name))</span>
+          <button type="button" class="btn" @onclick="() => RollSkill(skill)">Roll</button>
       </div>
   }
 </div>
@@ -17,6 +19,7 @@
 @code {
   [Parameter] public Character Character { get; set; } = default!;
   [Parameter] public bool IsReadOnly { get; set; }
+  [Parameter] public Guid CampaignId { get; set; }
 
   record Skill(string Name, string Display);
   Skill[] skills = new[] {
@@ -44,5 +47,13 @@
       var prof = Character.SkillProficiencies.FirstOrDefault(p => p.Name == name);
       if (value && prof == null) Character.SkillProficiencies.Add(new SkillProficiency { Name = name });
       if (!value && prof != null) Character.SkillProficiencies.Remove(prof);
+  }
+
+  async Task RollSkill(Skill skill)
+  {
+      var d20 = Random.Shared.Next(1, 21);
+      var result = d20 + Character.GetSkillValue(skill.Name);
+      var message = $"{Character.Name} testa {skill.Display}: {result}";
+      await JS.InvokeVoidAsync("chat.send", CampaignId.ToString(), Character.Name, message, true);
   }
 }


### PR DESCRIPTION
## Summary
- add campaign id and JS runtime to SkillsSection
- forward campaign ID to skill sections on character sheet and edit pages
- allow rolling skills and emit results to campaign chat

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35c1ddf188332bd72f3db3aeeda95