### PR TITLE
Add DiceRoller service and integrate roll expressions

### DIFF
--- a/RpgRooms.Core/Application/Services/DiceRoller.cs
+++ b/RpgRooms.Core/Application/Services/DiceRoller.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.RegularExpressions;
+using RpgRooms.Core.Domain.Entities;
+
+namespace RpgRooms.Core.Application.Services;
+
+public static class DiceRoller
+{
+    public record RollResult(int Total, string Detail);
+
+    public static RollResult Roll(string expr, Character character)
+    {
+        if (string.IsNullOrWhiteSpace(expr))
+            throw new ArgumentException("Expression cannot be empty", nameof(expr));
+
+        var detailParts = new List<string>();
+        var total = 0;
+        var normalized = expr.Replace(" ", string.Empty).ToUpperInvariant();
+        normalized = normalized.Replace("-", "+-");
+        var tokens = normalized.Split('+', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var token in tokens)
+        {
+            var term = token;
+            var sign = 1;
+            if (term.StartsWith('-'))
+            {
+                sign = -1;
+                term = term[1..];
+            }
+
+            int value;
+            string partDetail;
+            var match = Regex.Match(term, "^(\\d*)D(\\d+)$");
+            if (match.Success)
+            {
+                var count = string.IsNullOrEmpty(match.Groups[1].Value) ? 1 : int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
+                var sides = int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+                var rolls = new List<int>();
+                for (int i = 0; i < count; i++)
+                    rolls.Add(Random.Shared.Next(1, sides + 1));
+                value = rolls.Sum();
+                partDetail = $"{(sign == 1 ? string.Empty : "-")}{count}d{sides}({string.Join(',', rolls)})";
+            }
+            else if (IsAbility(term))
+            {
+                var ability = term[0] + term[1..].ToLowerInvariant();
+                value = character.GetAbilityModifier(ability);
+                partDetail = $"{(sign == 1 ? string.Empty : "-")}{term}({value})";
+            }
+            else if (term == "PB")
+            {
+                value = character.GetProficiencyBonus();
+                partDetail = $"{(sign == 1 ? string.Empty : "-")}PB({value})";
+            }
+            else if (int.TryParse(term, NumberStyles.Integer, CultureInfo.InvariantCulture, out var number))
+            {
+                value = number;
+                partDetail = $"{(sign == 1 ? string.Empty : "-")}{number}";
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid term '{term}' in expression", nameof(expr));
+            }
+            total += sign * value;
+            detailParts.Add(partDetail);
+        }
+        var detail = string.Join(" + ", detailParts).Replace("+-", "-");
+        return new RollResult(total, detail);
+    }
+
+    private static bool IsAbility(string token)
+        => token is "STR" or "DEX" or "CON" or "INT" or "WIS" or "CHA";
+}
+

--- a/RpgRooms.Tests/DiceRollerTests.cs
+++ b/RpgRooms.Tests/DiceRollerTests.cs
@@ -1,0 +1,36 @@
+using RpgRooms.Core.Application.Services;
+using RpgRooms.Core.Domain.Entities;
+using Xunit;
+
+namespace RpgRooms.Tests;
+
+public class DiceRollerTests
+{
+    [Fact]
+    public void Roll_ReplacesAbilitiesAndProficiency()
+    {
+        var character = new Character { Str = 16, Level = 5 };
+        var result = DiceRoller.Roll("1d1 + STR + PB + 2", character);
+        Assert.Equal(9, result.Total);
+        Assert.Contains("STR(3)", result.Detail);
+        Assert.Contains("PB(3)", result.Detail);
+    }
+
+    [Fact]
+    public void Roll_SupportsSubtraction()
+    {
+        var character = new Character { Dex = 14 };
+        var result = DiceRoller.Roll("1d1 + DEX - 2", character);
+        Assert.Equal(1 + 2 - 2, result.Total);
+        Assert.Contains("DEX(2)", result.Detail);
+    }
+
+    [Fact]
+    public void Roll_MultipleDice()
+    {
+        var character = new Character();
+        var result = DiceRoller.Roll("2d1", character);
+        Assert.Equal(2, result.Total);
+        Assert.StartsWith("2d1(1,1)", result.Detail);
+    }
+}

--- a/RpgRooms.Web/Pages/CharacterEdit.razor
+++ b/RpgRooms.Web/Pages/CharacterEdit.razor
@@ -23,7 +23,7 @@ else
         <CombatSection Character="character" IsReadOnly="IsReadOnly" />
         <LanguagesSection Character="character" IsReadOnly="IsReadOnly" />
         <FeaturesSection Character="character" IsReadOnly="IsReadOnly" />
-        <AttacksSection Character="character" IsReadOnly="IsReadOnly" />
+        <AttacksSection Character="character" IsReadOnly="IsReadOnly" CampaignId="campaignId" />
         <InventorySection Character="character" IsReadOnly="IsReadOnly" />
         <DescriptionSection Character="character" IsReadOnly="IsReadOnly" />
         <p>Percepção Passiva: @character.GetPassivePerception()</p>

--- a/RpgRooms.Web/Pages/CharacterSheet.razor
+++ b/RpgRooms.Web/Pages/CharacterSheet.razor
@@ -22,7 +22,7 @@ else
         <CombatSection Character="character" IsReadOnly="true" />
         <LanguagesSection Character="character" IsReadOnly="true" />
         <FeaturesSection Character="character" IsReadOnly="true" />
-        <AttacksSection Character="character" IsReadOnly="true" />
+        <AttacksSection Character="character" IsReadOnly="true" CampaignId="campaignId" />
         <InventorySection Character="character" IsReadOnly="true" />
         <DescriptionSection Character="character" IsReadOnly="true" />
         <p>Percepção Passiva: @character.GetPassivePerception()</p>

--- a/RpgRooms.Web/Pages/Characters/AttacksSection.razor
+++ b/RpgRooms.Web/Pages/Characters/AttacksSection.razor
@@ -1,4 +1,6 @@
 @using RpgRooms.Core.Domain.Entities
+@using RpgRooms.Core.Application.Services
+@inject IJSRuntime JS
 <div class="rpg-section">
   <h4>Ataques/Magias</h4>
   <ul>
@@ -7,6 +9,10 @@
         <li>@s.Name</li>
     }
   </ul>
+  <div>
+      <input class="rpg-input" @bind="rollExpr" placeholder="Rolagem (ex.: 1d20+STR+PB)" />
+      <button class="btn" @onclick="Roll">Roll</button>
+  </div>
   @if(!IsReadOnly)
   {
       <input class="rpg-input" @bind="newSpell" placeholder="Novo ataque ou magia" />
@@ -17,8 +23,11 @@
 @code {
   [Parameter] public Character Character { get; set; } = default!;
   [Parameter] public bool IsReadOnly { get; set; }
+  [Parameter] public Guid CampaignId { get; set; }
 
   string newSpell = string.Empty;
+  string rollExpr = string.Empty;
+
   void Add()
   {
       if(!string.IsNullOrWhiteSpace(newSpell))
@@ -26,5 +35,13 @@
           Character.Spells.Add(new Spell { Name = newSpell });
           newSpell = string.Empty;
       }
+  }
+
+  async Task Roll()
+  {
+      if (string.IsNullOrWhiteSpace(rollExpr)) return;
+      var result = DiceRoller.Roll(rollExpr, Character);
+      var message = $"{Character.Name} rola {rollExpr}: {result.Total} ({result.Detail})";
+      await JS.InvokeVoidAsync("chat.send", CampaignId.ToString(), Character.Name, message, true);
   }
 }

--- a/RpgRooms.Web/Pages/Characters/SkillsSection.razor
+++ b/RpgRooms.Web/Pages/Characters/SkillsSection.razor
@@ -1,4 +1,5 @@
 @using RpgRooms.Core.Domain.Entities
+@using RpgRooms.Core.Application.Services
 @inject IJSRuntime JS
 <div class="rpg-section">
   <h4>Perícias</h4>
@@ -21,26 +22,26 @@
   [Parameter] public bool IsReadOnly { get; set; }
   [Parameter] public Guid CampaignId { get; set; }
 
-  record Skill(string Name, string Display);
+  record Skill(string Name, string Display, string Ability);
   Skill[] skills = new[] {
-      new Skill("Acrobatics","Acrobatics (DEX)"),
-      new Skill("Animal Handling","Animal Handling (WIS)"),
-      new Skill("Arcana","Arcana (INT)"),
-      new Skill("Athletics","Athletics (STR)"),
-      new Skill("Deception","Deception (CHA)"),
-      new Skill("History","History (INT)"),
-      new Skill("Insight","Insight (WIS)"),
-      new Skill("Intimidation","Intimidation (CHA)"),
-      new Skill("Investigation","Investigation (INT)"),
-      new Skill("Medicine","Medicine (WIS)"),
-      new Skill("Nature","Nature (INT)"),
-      new Skill("Perception","Perception (WIS)"),
-      new Skill("Performance","Performance (CHA)"),
-      new Skill("Persuasion","Persuasion (CHA)"),
-      new Skill("Religion","Religion (INT)"),
-      new Skill("Sleight of Hand","Sleight of Hand (DEX)"),
-      new Skill("Stealth","Stealth (DEX)"),
-      new Skill("Survival","Survival (WIS)")
+      new Skill("Acrobatics","Acrobatics (DEX)","DEX"),
+      new Skill("Animal Handling","Animal Handling (WIS)","WIS"),
+      new Skill("Arcana","Arcana (INT)","INT"),
+      new Skill("Athletics","Athletics (STR)","STR"),
+      new Skill("Deception","Deception (CHA)","CHA"),
+      new Skill("History","History (INT)","INT"),
+      new Skill("Insight","Insight (WIS)","WIS"),
+      new Skill("Intimidation","Intimidation (CHA)","CHA"),
+      new Skill("Investigation","Investigation (INT)","INT"),
+      new Skill("Medicine","Medicine (WIS)","WIS"),
+      new Skill("Nature","Nature (INT)","INT"),
+      new Skill("Perception","Perception (WIS)","WIS"),
+      new Skill("Performance","Performance (CHA)","CHA"),
+      new Skill("Persuasion","Persuasion (CHA)","CHA"),
+      new Skill("Religion","Religion (INT)","INT"),
+      new Skill("Sleight of Hand","Sleight of Hand (DEX)","DEX"),
+      new Skill("Stealth","Stealth (DEX)","DEX"),
+      new Skill("Survival","Survival (WIS)","WIS")
   };
   void Toggle(string name, bool value)
   {
@@ -51,9 +52,11 @@
 
   async Task RollSkill(Skill skill)
   {
-      var d20 = Random.Shared.Next(1, 21);
-      var result = d20 + Character.GetSkillValue(skill.Name);
-      var message = $"{Character.Name} testa {skill.Display}: {result}";
+      var expr = $"1d20 + {skill.Ability}";
+      if (Character.SkillProficiencies.Any(p => p.Name == skill.Name))
+          expr += " + PB";
+      var result = DiceRoller.Roll(expr, Character);
+      var message = $"{Character.Name} testa {skill.Display}: {result.Total} ({result.Detail})";
       await JS.InvokeVoidAsync("chat.send", CampaignId.ToString(), Character.Name, message, true);
   }
 }


### PR DESCRIPTION
## Summary
- add `DiceRoller` utility to evaluate dice expressions and character bonuses
- hook DiceRoller into skills and attacks sections for chat-friendly roll messages
- cover dice roller with unit tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b35cf0a55c833282ee69c11ae62d27